### PR TITLE
Add GeoStreak country tally and result-card auto-fade

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -74,6 +74,8 @@ function initGeoStreak() {
   const MIN_THRESHOLD = 5;
   const MAX_THRESHOLD = 32;
   const ROUND_SECONDS = 20;
+  const RESULT_VISIBLE_MS = 4000; // how long a correct-guess card stays up before fading
+  const RESULT_FADE_MS = 500; // must match the CSS transition duration on .geo-result-fade-out
 
   const conditionEl = document.getElementById("gsCondition");
   const cityInput = document.getElementById("gsCityInput");
@@ -83,6 +85,7 @@ function initGeoStreak() {
   const resultEl = document.getElementById("gsResult");
   const streakEl = document.getElementById("gsStreak");
   const highScoreEl = document.getElementById("gsHighScore");
+  const countryTallyEl = document.getElementById("gsCountryTally");
   const playAreaEl = document.getElementById("gsPlayArea");
   const gameOverEl = document.getElementById("gsGameOver");
 
@@ -103,6 +106,10 @@ function initGeoStreak() {
   // resolved name, so "Auckland" then "Auckland,NZ" are still caught as the
   // same place even though the raw strings differ.
   let usedCities = new Set();
+
+  // How many guesses (correct or not, but only ones that resolved to a real
+  // place) have come from each country this session, keyed by ISO code.
+  let countryCounts = new Map();
 
   // Direction strictly alternates round to round (not a fresh coin flip
   // each time) — starting side is randomised once per session so it isn't
@@ -156,6 +163,24 @@ function initGeoStreak() {
     }, 1000);
   }
 
+  // Fades out and clears the result card a few seconds after a correct
+  // guess, so it doesn't linger on screen through the whole next round.
+  // Guarded by roundId: if a newer round's result has already replaced this
+  // one by the time the timers fire, this is a no-op — it must not wipe out
+  // a card that isn't the one it was scheduled for.
+  function scheduleResultFadeOut() {
+    const revealRoundId = roundId;
+    setTimeout(() => {
+      if (roundId !== revealRoundId) return;
+      resultEl.classList.add("geo-result-fade-out");
+      setTimeout(() => {
+        if (roundId !== revealRoundId) return;
+        resultEl.innerHTML = "";
+        resultEl.classList.remove("geo-result-fade-out");
+      }, RESULT_FADE_MS);
+    }, RESULT_VISIBLE_MS);
+  }
+
   function newCondition() {
     roundId += 1;
     const direction = nextDirection;
@@ -206,6 +231,10 @@ function initGeoStreak() {
     usedCities.add(typed.toLowerCase());
     usedCities.add(data.name.toLowerCase());
 
+    const countryCode = data.sys.country;
+    countryCounts.set(countryCode, (countryCounts.get(countryCode) || 0) + 1);
+    ui.updateCountryTally(countryTallyEl, countryCounts);
+
     const actual = data.main.temp;
     const correct = currentCondition.direction === "above"
       ? actual > currentCondition.threshold
@@ -223,6 +252,7 @@ function initGeoStreak() {
         ui.updateHighScoreDisplay(highScoreEl, highScore, { pulse: true });
       }
       newCondition();
+      scheduleResultFadeOut();
     } else {
       endGame();
     }
@@ -239,11 +269,14 @@ function initGeoStreak() {
   function restart() {
     streak = 0;
     usedCities = new Set();
+    countryCounts = new Map();
     usedThresholds.above.clear();
     usedThresholds.below.clear();
     nextDirection = Math.random() < 0.5 ? "above" : "below";
     ui.updateStreakDisplay(streakEl, streak);
+    ui.updateCountryTally(countryTallyEl, countryCounts);
     resultEl.innerHTML = "";
+    resultEl.classList.remove("geo-result-fade-out");
     gameOverEl.style.display = "none";
     playAreaEl.style.display = "";
     newCondition();

--- a/FPL/vannilaWeatherApp/ui.js
+++ b/FPL/vannilaWeatherApp/ui.js
@@ -378,6 +378,20 @@ class UI {
     el.classList.toggle("gs-timer-warn", secondsLeft > 5 && secondsLeft <= 10);
   }
 
+  // Renders the session's per-country breakdown, e.g. "🇺🇸 US ×2 | 🇮🇷 IR ×1",
+  // from a Map of ISO country code -> count. Reuses flagEmoji() rather than
+  // the CDN flagImg() — this is a compact inline tally, not a card header.
+  updateCountryTally(el, countryCounts) {
+    if (!el) return;
+    if (countryCounts.size === 0) {
+      el.innerHTML = "";
+      return;
+    }
+    el.innerHTML = [...countryCounts.entries()]
+      .map(([code, count]) => `${flagEmoji(code)} ${escapeHtml(code)} &times;${count}`)
+      .join(" &nbsp;|&nbsp; ");
+  }
+
   // `reason: "time"` distinguishes a timeout loss from a wrong-guess loss.
   renderGameOver(container, finalStreak, { reason } = {}) {
     if (!container) return;

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -47,6 +47,22 @@ turning amber under 10s and red under 5s. A guess still in flight when the
 timer expires is discarded when it resolves — it can't retroactively revive
 a round that already ended.
 
+## Result card auto-fade
+
+A correct guess's result card stays up for **~4 seconds**, then fades out
+over half a second and clears — so it doesn't linger on screen through the
+whole next round. A wrong guess's card (the one that ended the session) is
+left alone and stays visible on the Game Over screen. Guarded the same way
+as the round timer: if a new result has already replaced this one by the
+time the fade would fire, the stale fade-out is a no-op.
+
+## Country tally
+
+A running "🇬🇧 GB ×2 | 🇮🇷 IR ×1" breakdown under the stat boxes, one entry
+per country you've pulled a real reading from this session — correct or
+not, since even the guess that ends your streak still counts. Resets on
+Play Again along with everything else session-scoped.
+
 ## High score
 
 Current streak and **High Score** are both shown in stat boxes at the top
@@ -69,8 +85,8 @@ elements:
   `renderGameCard()` for the result reveal (a "CORRECT"/"INCORRECT" stamp
   on top of the same card look as the main app), plus small render helpers:
   `renderGameCondition`, `updateStreakDisplay`, `updateHighScoreDisplay`
-  (with pulse), `updateTimerDisplay`, `renderGameOver` (win/loss vs.
-  timeout heading).
+  (with pulse), `updateTimerDisplay`, `updateCountryTally`, `renderGameOver`
+  (win/loss vs. timeout heading).
 - **`../app.js`** — `initGeoStreak()` holds all game state (streak, high
   score, current condition, round timer, a `roundId` guard against
   stale in-flight guesses) and orchestrates the loop. Guarded on

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -122,6 +122,15 @@
       animation: gs-pulse 0.6s ease;
     }
 
+    .gs-country-tally {
+      text-align: center;
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.85rem;
+      color: #9db4de;
+      min-height: 1.4em;
+      margin-bottom: 22px;
+    }
+
     .gs-condition {
       text-align: center;
       font-size: 1.15rem;
@@ -187,6 +196,16 @@
     .geo-stamp-correct { color: #16a34a; }
     .geo-stamp-incorrect { color: #dc2626; }
 
+    /* Correct-guess result cards fade out a few seconds into the next
+       round rather than lingering on screen. Duration here must match
+       RESULT_FADE_MS in app.js. */
+    #gsResult {
+      transition: opacity 0.5s ease;
+    }
+    #gsResult.geo-result-fade-out {
+      opacity: 0;
+    }
+
     .gs-game-over {
       text-align: center;
     }
@@ -232,6 +251,8 @@
         <div class="gs-stat-value" id="gsHighScore">0</div>
       </div>
     </div>
+
+    <div class="gs-country-tally" id="gsCountryTally"></div>
 
     <div id="gsPlayArea">
       <p class="gs-condition" id="gsCondition"></p>


### PR DESCRIPTION
- Per-country breakdown (flag + ISO code + count) under the stat boxes, updated on every valid guess this session regardless of correct/incorrect.
- A correct guess's result card now fades out ~4s after being shown instead of lingering through the whole next round; a losing card is left alone on the Game Over screen. Guarded against a faster player's next result overwriting before the scheduled fade fires.
<img width="1294" height="1029" alt="image" src="https://github.com/user-attachments/assets/f0ab7f82-c1b7-4e4b-87f6-3a3a5072c9b9" />
