### PR TITLE
Make GeoStreak's temperature comparison inclusive at the threshold

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -331,9 +331,11 @@ function initGeoStreak() {
     citiesThisRun.add(cityKey);
 
     const actual = data.main.temp;
+    // Inclusive at the threshold itself — a reading exactly AT 14°C counts
+    // as satisfying "ABOVE 14°C", not just readings strictly past it.
     const tempCorrect = currentCondition.direction === "above"
-      ? actual > currentCondition.threshold
-      : actual < currentCondition.threshold;
+      ? actual >= currentCondition.threshold
+      : actual <= currentCondition.threshold;
 
     // Tough rounds (currentCondition.hemisphere set) need both the
     // temperature condition AND the hemisphere condition satisfied. Equator

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -21,7 +21,9 @@ main [Weather.JS](../index.html) page ("GeoStreak" button).
    "below"s in a row. A given (direction, threshold) question can't repeat
    until every threshold for that direction has been asked at least once
    (28 questions per direction, 56 total this session) — then that
-   direction's pool refills and can cycle again.
+   direction's pool refills and can cycle again. The comparison is
+   **inclusive** at the threshold — a reading of exactly 22°C satisfies
+   both "above 22°C" and "below 22°C".
 2. You type **any** place name (free text — no fixed list, no autocomplete)
    and hit Guess (or Enter).
 3. The app looks up that place's current temperature via the OpenWeatherMap


### PR DESCRIPTION
A reading exactly at the threshold (e.g. 14°C against "above 14°C") was being marked incorrect since the check used strict > / <.