### PR TITLE
Name the searched city in Weather.JS's not-found error

### DIFF
--- a/FPL/vannilaWeatherApp/fetch.js
+++ b/FPL/vannilaWeatherApp/fetch.js
@@ -14,8 +14,14 @@ class Fetch {
     // So we have to inspect the status ourselves and turn a bad one into
     // a thrown Error that app.js can catch in one place.
     if (!response.ok) {
-      // OpenWeather puts a human-readable reason in data.message, e.g.
-      // "city not found" (404) or "Invalid API key" (401).
+      // 404 gets its own message naming what was actually searched for,
+      // rather than OpenWeather's generic lowercase "city not found" —
+      // e.g. "daggercoil City not Found" instead of just "city not found".
+      if (response.status === 404) {
+        throw new Error(`${input} City not Found`);
+      }
+      // Other failures keep OpenWeather's human-readable reason, e.g.
+      // "Invalid API key" (401).
       throw new Error(data.message || `Request failed (${response.status})`);
     }
 

--- a/FPL/vannilaWeatherApp/ui.js
+++ b/FPL/vannilaWeatherApp/ui.js
@@ -171,11 +171,13 @@ class UI {
   }
 
   // Renders an error into the same spot the weather card normally occupies.
+  // Escaped because some callers (the 404 path) build this message from
+  // whatever the user just typed into the search box.
   showError(message) {
     this.stopClock(); // an error replaces the card, so kill any running clock
     this.uiContainer.innerHTML = `
       <div class="alert alert-danger text-center mx-auto mt-4" style="max-width: 20rem;">
-        ${message}
+        ${escapeHtml(message)}
       </div>`;
   }
 


### PR DESCRIPTION
A 404 now throws "<query> City not Found" instead of OpenWeather's generic "city not found", so the error reflects what was actually typed. showError() now escapes its message since this path feeds user input into innerHTML.

<img width="1564" height="865" alt="image" src="https://github.com/user-attachments/assets/342df1bf-24ee-4cc6-b290-626d1b6ddd8b" />
