### PR TITLE
Keep GeoStreak's search bar live in every state, reorder the layout

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -117,6 +117,7 @@ function initGeoStreak() {
   const playControlsEl = document.getElementById("gsPlayControls");
   const pausedEl = document.getElementById("gsPaused");
   const gameOverEl = document.getElementById("gsGameOver");
+  const insightsEl = document.getElementById("gsInsights");
 
   let streak = 0;
   let highScore = Number(localStorage.getItem(HIGH_SCORE_KEY)) || 0;
@@ -142,6 +143,18 @@ function initGeoStreak() {
   // still in flight when the round timer runs out (or the game restarts)
   // can tell its answer no longer belongs to the current round and drop it.
   let roundId = 0;
+
+  // Whether there's a live round to guess against right now. The search
+  // box is visible in every state (including before Start Game is ever
+  // pressed), so this is what tells submitGuess() whether to judge the
+  // input as a guess or just run it as a plain lookup, same as the main
+  // Weather.JS page's search.
+  let roundLive = false;
+
+  function setRoundLive(live) {
+    roundLive = live;
+    submitBtn.textContent = live ? "Guess" : "Search";
+  }
 
   // Cities already answered with this session (one continuous streak run,
   // cleared on restart) — lowercased so "Auckland" and "auckland" count as
@@ -263,6 +276,7 @@ function initGeoStreak() {
 
   function newCondition() {
     roundId += 1;
+    setRoundLive(true);
     playControlsEl.style.display = ""; // undo endGame()'s hide, in case this round follows one that ended
     const direction = nextDirection;
     nextDirection = direction === "above" ? "below" : "above"; // strictly alternate next round
@@ -285,10 +299,32 @@ function initGeoStreak() {
     startRoundTimer();
   }
 
+  // Used any time there's no live round to guess against — before Start
+  // Game is ever pressed, or after a run has ended. A plain lookup with no
+  // judging and no effect on any game state (country tally, city counts,
+  // used-cities list): exactly the same thing typing into the main
+  // Weather.JS search box would do.
+  async function runPlainSearch(typed) {
+    submitBtn.disabled = true;
+    try {
+      const data = await ft.getCurrent(typed);
+      ui.renderGameCard(resultEl, data, {});
+    } catch (err) {
+      ui.showError(err.message, resultEl);
+    }
+    submitBtn.disabled = false;
+  }
+
   async function submitGuess() {
     const typed = cityInput.value.trim();
     if (!typed) {
       hintEl.textContent = "Type a city name.";
+      return;
+    }
+
+    if (!roundLive) {
+      hintEl.textContent = "";
+      await runPlainSearch(typed);
       return;
     }
 
@@ -390,9 +426,12 @@ function initGeoStreak() {
   function enterPause() {
     paused = true;
     setPausePending(false);
+    setRoundLive(false);
     roundId += 1; // no round is live while paused — drop anything still in flight
     stopRoundTimer();
-    ui.renderPauseScreen(pausedEl, stats(), streak);
+    ui.renderPauseScreen(pausedEl, streak);
+    ui.renderInsights(insightsEl, stats());
+    insightsEl.style.display = "block";
     playAreaEl.style.display = "none";
     pausedEl.style.display = "block";
   }
@@ -400,6 +439,7 @@ function initGeoStreak() {
   function resume() {
     paused = false;
     pausedEl.style.display = "none";
+    insightsEl.style.display = "none";
     playAreaEl.style.display = "";
     clearResult();
     newCondition();
@@ -416,9 +456,13 @@ function initGeoStreak() {
     roundId += 1; // invalidate any guess still in flight for the round that just ended
     stopRoundTimer();
     setPausePending(false);
+    setRoundLive(false);
+    hintEl.textContent = "";
     gamesPlayed += 1;
     localStorage.setItem(GAMES_PLAYED_KEY, String(gamesPlayed));
-    ui.renderGameOver(gameOverEl, streak, { reason, stats: stats(), uniqueCities: citiesThisRun.size });
+    ui.renderGameOver(gameOverEl, streak, { reason, uniqueCities: citiesThisRun.size });
+    ui.renderInsights(insightsEl, stats());
+    insightsEl.style.display = "block";
     // Play area stays visible (unlike Pause/Start) so the last question —
     // the one the run ended on — is still readable next to the result
     // card below; only the now-irrelevant input/timer/hint are hidden.
@@ -441,6 +485,8 @@ function initGeoStreak() {
     nextHemisphere = Math.random() < 0.5 ? "north" : "south";
     paused = false;
     setPausePending(false);
+    setRoundLive(false);
+    hintEl.textContent = "";
     ui.updateStreakDisplay(streakEl, streak);
     ui.updateCountryTally(countryTallyEl, countryCounts);
     clearResult();
@@ -448,8 +494,10 @@ function initGeoStreak() {
 
   function showStartScreen() {
     resetSession();
-    ui.renderStartScreen(startEl, stats());
+    ui.renderStartScreen(startEl);
+    ui.renderInsights(insightsEl, stats());
     startEl.style.display = "block";
+    insightsEl.style.display = "block";
     playAreaEl.style.display = "none";
     pausedEl.style.display = "none";
     gameOverEl.style.display = "none";
@@ -460,6 +508,7 @@ function initGeoStreak() {
     startEl.style.display = "none";
     pausedEl.style.display = "none";
     gameOverEl.style.display = "none";
+    insightsEl.style.display = "none";
     playAreaEl.style.display = "";
     newCondition();
   }

--- a/FPL/vannilaWeatherApp/ui.js
+++ b/FPL/vannilaWeatherApp/ui.js
@@ -186,10 +186,13 @@ class UI {
 
   // Renders an error into the same spot the weather card normally occupies.
   // Escaped because some callers (the 404 path) build this message from
-  // whatever the user just typed into the search box.
-  showError(message) {
+  // whatever the user just typed into the search box. `container` defaults
+  // to the main app's own card slot, but GeoStreak's plain (non-guess)
+  // searches pass its own result div instead, since that page has no
+  // #content element.
+  showError(message, container = this.uiContainer) {
     this.stopClock(); // an error replaces the card, so kill any running clock
-    this.uiContainer.innerHTML = `
+    container.innerHTML = `
       <div class="alert alert-danger text-center mx-auto mt-4" style="max-width: 20rem;">
         ${escapeHtml(message)}
       </div>`;
@@ -351,17 +354,20 @@ class UI {
   // `isNewCity` (the city has never been attempted before, lifetime, on
   // this browser) briefly brightens the card via the CSS gs-brighten
   // animation — it's a fresh element each call, so unlike the streak pulse
-  // there's no reflow trick needed to retrigger it.
+  // there's no reflow trick needed to retrigger it. `correct` is omitted
+  // entirely (not false) for a plain lookup made outside a live round —
+  // that's not a judged guess, so no CORRECT/INCORRECT stamp applies.
   renderGameCard(container, data, { correct, isNewCity } = {}) {
     if (!container) return;
     const cardHtml = this.buildWeatherCardHtml(data, null);
-    const stampClass = correct ? "geo-stamp-correct" : "geo-stamp-incorrect";
-    const stampText = correct ? "CORRECT" : "INCORRECT";
     const newCityClass = isNewCity ? "geo-new-city" : "";
+    const stampHtml = typeof correct === "boolean"
+      ? `<div class="geo-stamp ${correct ? "geo-stamp-correct" : "geo-stamp-incorrect"}">${correct ? "CORRECT" : "INCORRECT"}</div>`
+      : "";
 
     container.innerHTML = `
       <div class="geo-result-wrap ${newCityClass}">
-        <div class="geo-stamp ${stampClass}">${stampText}</div>
+        ${stampHtml}
         ${cardHtml}
       </div>
     `;
@@ -482,9 +488,12 @@ class UI {
     `;
   }
 
-  // First screen on load: the rules and the player's running numbers, so
-  // there's something to beat before the first question appears.
-  renderStartScreen(container, stats) {
+  // First screen on load: the rules and a prominent Start button, so
+  // there's no scrolling past numbers to get into a round. The player's
+  // running numbers still exist (renderInsights, rendered into its own
+  // container below the result card) — just not fighting the button for
+  // top billing.
+  renderStartScreen(container) {
     if (!container) return;
     container.innerHTML = `
       <div class="gs-panel">
@@ -492,8 +501,7 @@ class UI {
         <p class="gs-panel-sub">
           Name a city whose current temperature matches the condition. Keep the streak alive.
         </p>
-        ${this.buildInsightsHtml(stats)}
-        ${this.buildCityInsightsHtml(stats)}
+        <button type="button" id="gsStartBtn" class="btn btn-primary">Start Game</button>
         <ul class="gs-howto">
           <li>20 seconds per round.</li>
           <li>Each city can only be used once per run.</li>
@@ -501,19 +509,16 @@ class UI {
           <li>A city we can't find costs you nothing but time.</li>
           <li>From question 11 on, rounds get tough: a hemisphere is added to the condition, and both parts have to match.</li>
         </ul>
-        <button type="button" id="gsStartBtn" class="btn btn-primary">Start Game</button>
       </div>
     `;
   }
 
-  renderPauseScreen(container, stats, currentStreak) {
+  renderPauseScreen(container, currentStreak) {
     if (!container) return;
     container.innerHTML = `
       <div class="gs-panel">
         <h3>Paused</h3>
         <p class="gs-panel-sub">Current streak: <b>${currentStreak}</b> &mdash; still alive.</p>
-        ${this.buildInsightsHtml(stats)}
-        ${this.buildCityInsightsHtml(stats)}
         <button type="button" id="gsResumeBtn" class="btn btn-primary">Resume</button>
       </div>
     `;
@@ -522,7 +527,7 @@ class UI {
   // `reason: "time"` distinguishes a timeout loss from a wrong-guess loss.
   // `uniqueCities` is this run's count (not lifetime) — how many different
   // real places were pulled a reading from before the run ended.
-  renderGameOver(container, finalStreak, { reason, stats, uniqueCities = 0 } = {}) {
+  renderGameOver(container, finalStreak, { reason, uniqueCities = 0 } = {}) {
     if (!container) return;
     const heading = reason === "time" ? "Time's Up!" : "Game Over";
     container.innerHTML = `
@@ -530,9 +535,22 @@ class UI {
         <h3>${heading}</h3>
         <p class="gs-panel-sub">Final streak: <b>${finalStreak}</b></p>
         <p class="gs-panel-sub">Unique cities this run: <b>${uniqueCities}</b></p>
+        <button type="button" id="gsPlayAgain" class="btn btn-warning">Play Again</button>
+      </div>
+    `;
+  }
+
+  // The lifetime numbers, shared by the start/pause/game-over states —
+  // rendered into its own container (below the result card, so a fresh
+  // guess/search result isn't buried under it) rather than embedded in
+  // each panel above, which is what used to push the action button down
+  // behind a wall of stats and the city list.
+  renderInsights(container, stats) {
+    if (!container) return;
+    container.innerHTML = `
+      <div class="gs-panel">
         ${this.buildInsightsHtml(stats)}
         ${this.buildCityInsightsHtml(stats)}
-        <button type="button" id="gsPlayAgain" class="btn btn-warning">Play Again</button>
       </div>
     `;
   }

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -67,7 +67,7 @@ Play Again.
 
 ## Round timer
 
-Each round gives you **20 seconds**. It's shown live below the input,
+Each round gives you **20 seconds**. It's shown live below the condition,
 turning amber under 10s and red under 5s. A guess still in flight when the
 timer expires is discarded when it resolves — it can't retroactively revive
 a round that already ended.
@@ -92,13 +92,34 @@ tracked.
 Unlike Pause and Start, ending a run doesn't hide the round you were on: the
 **last question stays on screen**, right above the Game Over panel and the
 result card that ended things, so you can see exactly what you missed (or
-ran out of time on). Only the now-irrelevant input box, timer and pause
-button are hidden — there's nothing left to answer.
+ran out of time on). Only the now-irrelevant timer and pause button are
+hidden — the search box stays put (see below).
 
 The Game Over panel also shows **unique cities this run** — how many
 different real places you pulled a reading from before the run ended
 (correct guesses and the one that ended it, not duplicates or not-founds).
 This is a per-run count, not the lifetime one below.
+
+## The search box is always there
+
+The city input and its button sit at the top of the page in every state —
+before Start Game is ever pressed, mid-round, paused, and after Game
+Over — rather than only existing while a round is live. Whether a search
+counts as a **guess** depends entirely on whether there's a live round to
+judge it against:
+
+- **Live round** → button reads "Guess"; the input is judged against the
+  current condition exactly as described above, and affects streak,
+  lifetime stats, the country tally, and the used-cities list.
+- **No live round** (start screen, paused, game over) → button reads
+  "Search"; it's a plain city lookup with **no judging and no side
+  effects on any game state** — the same thing typing into the main
+  Weather.JS search box would do. The result renders as an unstamped
+  card (no CORRECT/INCORRECT) in the same result slot a guess would use.
+
+This means you can look up a city's weather before starting a run, or
+between runs, without it costing you a used-city slot or counting toward
+your lifetime attempt numbers.
 
 ## City tracking & insights
 
@@ -134,8 +155,9 @@ and pulses when the current streak overtakes it.
 ## Start screen and insights
 
 The page opens on a **Start Game** panel — no question is generated and no
-timer runs until you press it. Alongside the rules, the panel shows your
-all-time numbers so there's a target before the first round:
+timer runs until you press it. The button sits right under the rules, right
+below the search box; your all-time numbers are deliberately **not** in this
+panel — see below for where they live.
 
 | Insight | Source |
 | --- | --- |
@@ -151,10 +173,14 @@ that simply timed out are *not* attempts — so accuracy measures geography
 rather than typing. Accuracy is computed at render time rather than stored,
 so it can't drift out of step with the two counters behind it.
 
-The same numbers (plus Top Cities, once eligible) appear on the pause and
-game-over panels. All of them are lifetime and browser-local: they survive
-Play Again, and only the streak, used cities and country tally reset with a
-new run.
+These numbers render into their own block, **below the result card**,
+whenever the start, pause or game-over panel is showing (hidden during an
+active round). Keeping them out of those panels means the primary action
+button — Start Game, Resume, Play Again — is never buried under a wall of
+stats and a top-5 city list; the result card from your last guess or search
+gets the prime spot instead. All of the numbers are lifetime and
+browser-local: they survive Play Again, and only the streak, used cities
+and country tally reset with a new run.
 
 ## Pause
 
@@ -189,10 +215,13 @@ elements:
   on top of the same card look as the main app), plus small render helpers:
   `renderGameCondition`, `updateStreakDisplay`, `updateHighScoreDisplay`
   (with pulse), `updateTimerDisplay`, `updateCountryTally`,
-  `updatePauseButton`, and the three panel renderers — `renderStartScreen`,
-  `renderPauseScreen`, `renderGameOver` (win/loss vs. timeout heading) —
-  which all share one `buildInsightsHtml()` and one `buildCityInsightsHtml()`
-  so the numbers can't be formatted three different ways.
+  `updatePauseButton`, the three compact panel renderers —
+  `renderStartScreen`, `renderPauseScreen`, `renderGameOver` (win/loss vs.
+  timeout heading) — and `renderInsights`, the shared numbers block those
+  three panels used to embed directly but now render separately (below the
+  result card) via one `buildInsightsHtml()` and one
+  `buildCityInsightsHtml()`, so the numbers can't be formatted four
+  different ways.
 - **`../app.js`** — `initGeoStreak()` holds all game state (streak, high
   score, lifetime counters, lifetime per-city log, current condition, round
   timer, pause state, and a `roundId` guard against stale in-flight guesses)

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -387,6 +387,23 @@
 
     <div class="gs-country-tally" id="gsCountryTally"></div>
 
+    <!-- Always visible, in every state, including before Start Game is ever
+         pressed: while a round is live this is a guess; otherwise it's a
+         plain city weather lookup, same as the main Weather.JS search. -->
+    <div id="gsSearchRow">
+      <div class="gs-input-row">
+        <input
+          type="text"
+          id="gsCityInput"
+          class="form-control"
+          placeholder="Type a city name…"
+          autocomplete="off"
+        />
+        <button type="button" id="gsSubmit" class="btn btn-primary">Search</button>
+      </div>
+      <p class="gs-hint" id="gsHint"></p>
+    </div>
+
     <!-- Start / pause / game-over panels are all rendered by ui.js; the play
          area is the only screen written out as static markup. Exactly one of
          the four is visible at a time. -->
@@ -394,24 +411,13 @@
 
     <div id="gsPlayArea" style="display: none;">
       <p class="gs-condition" id="gsCondition"></p>
-      <!-- Everything below is hidden on Game Over so the round's last
-           question (above) stays visible next to the result card. -->
+      <!-- Hidden on Game Over so the round's last question (above) stays
+           visible next to the result card, without a dead timer under it. -->
       <div id="gsPlayControls">
-        <div class="gs-input-row">
-          <input
-            type="text"
-            id="gsCityInput"
-            class="form-control"
-            placeholder="Type a city name…"
-            autocomplete="off"
-          />
-          <button type="button" id="gsSubmit" class="btn btn-primary">Guess</button>
-        </div>
         <div class="gs-timer-row">
           <div class="gs-timer" id="gsTimer">20s</div>
           <button type="button" id="gsPause" class="gs-pause-btn">&#9208; PAUSE</button>
         </div>
-        <p class="gs-hint" id="gsHint"></p>
       </div>
     </div>
 
@@ -420,6 +426,12 @@
     <div id="gsGameOver" style="display: none;"></div>
 
     <div id="gsResult"></div>
+
+    <!-- Lifetime numbers (streak/correct/attempts/accuracy + top cities),
+         shared across the start/pause/game-over states and deliberately
+         placed below the result card so a fresh guess/search isn't buried
+         under a wall of stats. -->
+    <div id="gsInsights" style="display: none;"></div>
 
     <footer class="gs-footer">
       <a


### PR DESCRIPTION
Search box now sits at the top always, usable before Start Game is ever pressed and after a run ends: with no live round to judge it against, a search is just a plain city lookup (unstamped card, no effect on game state) instead of a guess. Button label reflects the mode ("Guess" vs "Search").

Also moves the Start/Resume/Play Again button up (right under the search bar) and the lifetime stats/top-cities panel down (below the result card, via a new shared renderInsights()), so the primary action and the latest result aren't buried under a wall of numbers.
<img width="1368" height="1025" alt="image" src="https://github.com/user-attachments/assets/132e6d66-6a65-454e-8b7c-4e60a72a776f" />
