### PR TITLE
Add an optional online leaderboard to GeoStreak (Firebase, free tier)

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -432,6 +432,7 @@ function initGeoStreak() {
     ui.renderPauseScreen(pausedEl, streak);
     ui.renderInsights(insightsEl, stats());
     insightsEl.style.display = "block";
+    if (typeof Leaderboard !== "undefined") Leaderboard.showPanel();
     playAreaEl.style.display = "none";
     pausedEl.style.display = "block";
   }
@@ -440,6 +441,7 @@ function initGeoStreak() {
     paused = false;
     pausedEl.style.display = "none";
     insightsEl.style.display = "none";
+    if (typeof Leaderboard !== "undefined") Leaderboard.hidePanel();
     playAreaEl.style.display = "";
     clearResult();
     newCondition();
@@ -463,6 +465,10 @@ function initGeoStreak() {
     ui.renderGameOver(gameOverEl, streak, { reason, uniqueCities: citiesThisRun.size });
     ui.renderInsights(insightsEl, stats());
     insightsEl.style.display = "block";
+    if (typeof Leaderboard !== "undefined") {
+      Leaderboard.submitScore(streak, stats());
+      Leaderboard.showPanel();
+    }
     // Play area stays visible (unlike Pause/Start) so the last question —
     // the one the run ended on — is still readable next to the result
     // card below; only the now-irrelevant input/timer/hint are hidden.
@@ -498,6 +504,7 @@ function initGeoStreak() {
     ui.renderInsights(insightsEl, stats());
     startEl.style.display = "block";
     insightsEl.style.display = "block";
+    if (typeof Leaderboard !== "undefined") Leaderboard.showPanel();
     playAreaEl.style.display = "none";
     pausedEl.style.display = "none";
     gameOverEl.style.display = "none";
@@ -509,6 +516,7 @@ function initGeoStreak() {
     pausedEl.style.display = "none";
     gameOverEl.style.display = "none";
     insightsEl.style.display = "none";
+    if (typeof Leaderboard !== "undefined") Leaderboard.hidePanel();
     playAreaEl.style.display = "";
     newCondition();
   }

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -233,6 +233,85 @@ elements:
   the play area is static markup; start, pause and game-over are rendered
   into empty containers, so their buttons are wired by delegating clicks
   from the container rather than binding elements that get replaced.
+- **`firebaseConfig.js`** / **`leaderboard.js`** / **`firestore.rules`** —
+  the optional online leaderboard (see [Leaderboard](#leaderboard) above).
+  Firebase's compat SDK (loaded via `<script>` tags, matching this
+  project's no-bundler style) plus `leaderboard.js` must both come
+  *before* `../app.js` in `geoStreakGame.html` — `app.js` calls
+  `showStartScreen()` synchronously as soon as it loads, and that needs
+  the `Leaderboard` global (and `escapeHtml` from `../ui.js`) to already
+  exist.
+
+## Leaderboard
+
+An optional, **entirely client-judged** online leaderboard, backed by
+Firebase Firestore on the free Spark plan. "Client-judged" is the
+important qualifier: correct/incorrect is still decided in the browser
+exactly as described above, and only the final streak gets shared — so
+this is gameable via devtools the same way hand-editing `localStorage`
+already was. It's a real shared leaderboard for a casual personal project,
+not an anti-cheat system. See [Why not fully secure](#why-not-fully-secure)
+below for what closing that gap would actually take.
+
+### Setup (one-time, per Firebase project)
+
+1. **Create a project** at [console.firebase.google.com](https://console.firebase.google.com/) — free, no credit card (Spark plan).
+2. **Enable Firestore**: Build -> Firestore Database -> Create database -> start in **production mode** (the rules below replace the default-deny anyway) -> pick any region.
+3. **Enable Anonymous sign-in**: Build -> Authentication -> Get started -> Sign-in method -> Anonymous -> Enable. This is what gives each browser a stable identity with zero login UI — no email, no password, nothing the player has to do.
+4. **Register a web app**: Project settings (gear icon) -> General -> "Your apps" -> the `</>` (web) icon -> register it (a nickname is enough, no hosting setup needed) -> copy the `firebaseConfig` object it shows you.
+5. **Paste that config into [`firebaseConfig.js`](./firebaseConfig.js)**, replacing the six `REPLACE_ME` placeholders. These values are not secret (see the comment at the top of that file for why) — access control is entirely the rules file's job, not this object's.
+6. **Publish the security rules**: Firestore Database -> Rules tab -> replace the contents with [`firestore.rules`](./firestore.rules) -> Publish.
+
+That's it — no CLI, no `firebase login`, no deploy step. Until step 5 is
+done, `leaderboard.js` detects the placeholder and the panel just shows
+"Leaderboard not configured yet" — the rest of GeoStreak is completely
+unaffected either way.
+
+### Data model
+
+One Firestore document per player, in the `geostreakLeaderboard`
+collection, keyed by their anonymous-auth uid:
+
+```
+{ nickname: "Player4492", bestStreak: 22, totalCorrect: 125, totalAttempts: 139, updatedAt: <server timestamp> }
+```
+
+A **nickname** defaults to a random `PlayerNNNN`, editable any time from
+the leaderboard panel's input — stored in
+`localStorage["geoStreakGame_nickname"]`, and re-sent on every write so
+renaming updates future leaderboard rows without needing a migration.
+
+A run's final streak is only ever submitted **on Game Over**, and only if
+it's positive — a losing run's low number was never a personal best worth
+recording. The write is a `set(..., { merge: true })` upsert, not an
+append: there's exactly one row per player, always their personal best,
+never a full history of every run.
+
+### Why the rules file is the part that actually matters
+
+Anyone can read the leaderboard, but a write is only accepted if:
+
+- it comes from the signed-in owner of that document (`request.auth.uid == uid`),
+- every field is present, the right type, and within sane bounds (nickname ≤ 20 chars, `0 < bestStreak <= 500`, etc.), and
+- **on an update, the new `bestStreak` is strictly greater than the one already stored.**
+
+That last check is the one doing real work. Without it, a player could
+resubmit a lower number later (say, after a bad run) and silently
+overwrite a real personal best — Firestore itself enforces "scores only go
+up," so the client doesn't have to be trusted for that specific guarantee,
+even though it's still trusted for *what counts as correct* in the first place.
+
+### Why not fully secure
+
+The only way to close the "devtools can just write the score directly"
+gap for real is to stop trusting the client for *correctness* too — move
+the guess-judging itself into a Cloud Function that calls OpenWeatherMap
+server-side and returns a verdict the browser can't fabricate, then only
+accept a leaderboard write that references a verdict the function itself
+issued. That needs the paid Blaze plan (Cloud Functions require outbound
+networking, unavailable on Spark) and is a real rework of the round loop,
+not an add-on — deliberately out of scope here in favour of shipping a
+working shared leaderboard today.
 
 ## Visual design
 

--- a/FPL/vannilaWeatherApp/weatherGame/firebaseConfig.js
+++ b/FPL/vannilaWeatherApp/weatherGame/firebaseConfig.js
@@ -1,0 +1,21 @@
+// Fill these in from your own Firebase project's web app config:
+// Firebase console -> Project settings -> General -> "Your apps" -> Web
+// app -> SDK setup and configuration -> Config.
+//
+// These values are NOT secret — Firebase's web config identifies which
+// project to talk to, the same way the OpenWeatherMap key in ../fetch.js
+// already sits in plain text client-side. Actual access control is
+// enforced by firestore.rules (see the README's Leaderboard section for
+// how to deploy it), not by hiding this object.
+//
+// Until every REPLACE_ME below is filled in, leaderboard.js detects the
+// placeholder and no-ops everywhere — the rest of GeoStreak works exactly
+// as before, just without the online leaderboard panel.
+const firebaseConfig = {
+  apiKey: "REPLACE_ME",
+  authDomain: "REPLACE_ME.firebaseapp.com",
+  projectId: "REPLACE_ME",
+  storageBucket: "REPLACE_ME.appspot.com",
+  messagingSenderId: "REPLACE_ME",
+  appId: "REPLACE_ME",
+};

--- a/FPL/vannilaWeatherApp/weatherGame/firestore.rules
+++ b/FPL/vannilaWeatherApp/weatherGame/firestore.rules
@@ -1,0 +1,49 @@
+// GeoStreak leaderboard rules — paste into Firebase console -> Firestore
+// Database -> Rules -> replace the contents -> Publish. This project has
+// no Firebase Hosting / CLI deploy set up, so this file is documentation
+// + copy-paste source, not something that deploys itself.
+//
+// One document per player, keyed by their anonymous-auth uid. The single
+// rule that actually matters for cheat-resistance is the bestStreak
+// comparison on update — everything else here is shape/bounds validation,
+// which stops garbage data but not a determined cheater with devtools
+// open. See the README's Leaderboard section for what it would take to
+// close that gap for real (short version: judge guesses server-side via
+// a Cloud Function, which needs the paid Blaze plan).
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /geostreakLeaderboard/{uid} {
+      // Public leaderboard — anyone can read the rankings, signed in or not.
+      allow read: if true;
+
+      // A player may only ever write their OWN document (their uid is the
+      // document id), and only with a shape that passes isValidEntry().
+      allow create: if request.auth != null
+        && request.auth.uid == uid
+        && isValidEntry(request.resource.data);
+
+      // An update additionally has to actually beat the stored streak —
+      // this is what stops a losing run's lower number (or a replayed
+      // stale write) from clobbering a real personal best.
+      allow update: if request.auth != null
+        && request.auth.uid == uid
+        && isValidEntry(request.resource.data)
+        && request.resource.data.bestStreak > resource.data.bestStreak;
+
+      allow delete: if false;
+    }
+  }
+
+  function isValidEntry(data) {
+    return data.keys().hasOnly(['nickname', 'bestStreak', 'totalCorrect', 'totalAttempts', 'updatedAt'])
+      && data.nickname is string && data.nickname.size() > 0 && data.nickname.size() <= 20
+      && data.bestStreak is int && data.bestStreak > 0 && data.bestStreak <= 500
+      && data.totalCorrect is int && data.totalCorrect >= 0
+      && data.totalAttempts is int && data.totalAttempts >= data.totalCorrect
+      // Rejects a client-supplied timestamp — serverTimestamp() is the
+      // only value that resolves to request.time, so this forces the
+      // write to actually use it rather than a spoofed date.
+      && data.updatedAt == request.time;
+  }
+}

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -342,6 +342,63 @@
       white-space: nowrap;
     }
 
+    .gs-nickname-row {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 14px;
+    }
+    .gs-leaderboard-note {
+      color: #6b7fa8;
+      font-size: 0.85rem;
+      font-style: italic;
+    }
+    .gs-leaderboard-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      text-align: left;
+    }
+    .gs-leaderboard-list li {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.85rem;
+      padding: 5px 4px;
+      border-bottom: 1px solid #1b2a4a;
+    }
+    .gs-leaderboard-list li:last-child { border-bottom: none; }
+    /* Your own row, wherever it falls in the ranking. */
+    .gs-leaderboard-list li.gs-leaderboard-me {
+      background: #12244a;
+      border-radius: 4px;
+    }
+    .gs-leaderboard-rank {
+      font-family: "Courier New", Courier, monospace;
+      color: #6b7fa8;
+      width: 1.6em;
+      text-align: right;
+      flex-shrink: 0;
+    }
+    .gs-leaderboard-name {
+      color: #cfe8ff;
+      flex: 1 1 auto;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .gs-leaderboard-streak {
+      font-family: "Courier New", Courier, monospace;
+      color: #7dd3fc;
+      font-weight: bold;
+    }
+    .gs-leaderboard-accuracy {
+      font-family: "Courier New", Courier, monospace;
+      color: #6b7fa8;
+      font-size: 0.75rem;
+      width: 3em;
+      text-align: right;
+    }
+
     .gs-howto {
       text-align: left;
       font-size: 0.85rem;
@@ -433,6 +490,27 @@
          under a wall of stats. -->
     <div id="gsInsights" style="display: none;"></div>
 
+    <!-- Online leaderboard (Firebase Firestore, optional — see
+         leaderboard.js and the README's Leaderboard section). Shown/hidden
+         alongside gsInsights above. -->
+    <div id="gsLeaderboard" style="display: none;">
+      <div class="gs-panel">
+        <h3>Leaderboard</h3>
+        <div class="gs-nickname-row">
+          <input
+            type="text"
+            id="gsNickname"
+            class="form-control"
+            maxlength="20"
+            placeholder="Your name"
+            autocomplete="off"
+          />
+          <button type="button" id="gsNicknameSave" class="btn btn-secondary btn-sm">Save</button>
+        </div>
+        <div id="gsLeaderboardList"></div>
+      </div>
+    </div>
+
     <footer class="gs-footer">
       <a
         href="https://github.com/TenForBen/TenForBen.github.io/blob/feature/geoStreakGame/FPL/vannilaWeatherApp/weatherGame/README.md"
@@ -445,6 +523,19 @@
 
   <script src="../fetch.js"></script>
   <script src="../ui.js"></script>
+
+  <!-- Firebase (compat build — matches this codebase's plain-<script>,
+       no-bundler style rather than the modular/ESM SDK). Optional: see
+       firebaseConfig.js and leaderboard.js. Must load before app.js: app.js
+       calls initGeoStreak() -> showStartScreen() synchronously as soon as
+       it runs, and that call needs the `Leaderboard` global to already
+       exist (uses escapeHtml from ui.js above, so it comes after that). -->
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-firestore-compat.js"></script>
+  <script src="firebaseConfig.js"></script>
+  <script src="leaderboard.js"></script>
+
   <script src="../app.js"></script>
 </body>
 </html>

--- a/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
+++ b/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
@@ -1,0 +1,174 @@
+// GeoStreak's online leaderboard — Firebase Firestore on the free Spark
+// plan, so it's entirely client-judged: the browser still decides
+// correct/incorrect exactly as before, and only the final streak gets
+// shared. That means it's gameable via devtools the same way the
+// "just edit localStorage" version already was — see firestore.rules and
+// the README's Leaderboard section for exactly what it does and doesn't
+// protect against, and what it would take to close that gap properly.
+//
+// Entirely optional: if firebaseConfig.js still has its REPLACE_ME
+// placeholders, every function here no-ops and the leaderboard panel shows
+// a "not configured" note instead of breaking the rest of the game.
+//
+// Guarded on #gsLeaderboard so this file can also be safely included on a
+// page that doesn't have one, same convention app.js uses for its two
+// init functions.
+const Leaderboard = (() => {
+  const NICKNAME_KEY = "geoStreakGame_nickname";
+  const COLLECTION = "geostreakLeaderboard";
+  const TOP_N = 20;
+
+  const configured = typeof firebaseConfig !== "undefined"
+    && firebaseConfig.apiKey
+    && !firebaseConfig.apiKey.startsWith("REPLACE_ME");
+
+  let db = null;
+  let uid = null;
+  // Resolves once anonymous sign-in has produced a uid — every read/write
+  // below awaits this first, so a call made right on page load doesn't
+  // race the auth handshake.
+  let ready = Promise.resolve();
+
+  function randomNickname() {
+    return `Player${Math.floor(1000 + Math.random() * 9000)}`;
+  }
+
+  function getNickname() {
+    return localStorage.getItem(NICKNAME_KEY) || randomNickname();
+  }
+
+  function setNickname(name) {
+    const trimmed = name.trim().slice(0, 20);
+    if (trimmed) localStorage.setItem(NICKNAME_KEY, trimmed);
+    return getNickname();
+  }
+
+  function init() {
+    // Wired up either way — saving a nickname locally is harmless even
+    // before Firebase is configured, and it means the name's already set
+    // the moment someone does fill in firebaseConfig.js.
+    wireNicknameInput();
+    if (!configured) return;
+    firebase.initializeApp(firebaseConfig);
+    db = firebase.firestore();
+    const auth = firebase.auth();
+
+    ready = auth.signInAnonymously()
+      .then(() => new Promise((resolve) => {
+        const unsubscribe = auth.onAuthStateChanged((user) => {
+          if (!user) return;
+          uid = user.uid;
+          unsubscribe();
+          resolve();
+        });
+      }))
+      .catch((err) => {
+        // Offline, blocked by an extension, project misconfigured, etc. —
+        // the leaderboard just silently stays empty; nothing else in the
+        // game depends on this promise resolving.
+        console.error("Leaderboard: anonymous sign-in failed", err);
+      });
+  }
+
+  function wireNicknameInput() {
+    const input = document.getElementById("gsNickname");
+    const saveBtn = document.getElementById("gsNicknameSave");
+    if (!input || !saveBtn) return;
+    input.value = getNickname();
+    saveBtn.addEventListener("click", () => {
+      input.value = setNickname(input.value);
+    });
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") saveBtn.click();
+    });
+  }
+
+  // Called once a run ends. Only writes on a positive streak — a losing
+  // run's final number is never itself a personal best worth recording.
+  // The write can still be rejected outright by firestore.rules if it
+  // doesn't actually beat this player's stored bestStreak; that's the
+  // real gate, not anything checked here.
+  async function submitScore(streak, stats) {
+    if (!configured || streak <= 0) return;
+    await ready;
+    if (!uid) return;
+    try {
+      await db.collection(COLLECTION).doc(uid).set({
+        nickname: getNickname(),
+        bestStreak: streak,
+        totalCorrect: stats.totalCorrect,
+        totalAttempts: stats.totalAttempts,
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    } catch (err) {
+      // Most commonly: rules rejected a non-improving score, or the
+      // player's offline. Either way, failing silently is correct here —
+      // a rejected background write shouldn't interrupt the game.
+      console.error("Leaderboard: submitScore failed", err);
+    }
+  }
+
+  function renderRow(doc, rank) {
+    const d = doc.data();
+    const accuracy = d.totalAttempts
+      ? `${Math.round((d.totalCorrect / d.totalAttempts) * 100)}%`
+      : "—";
+    const mine = doc.id === uid ? " gs-leaderboard-me" : "";
+    return `
+      <li class="${mine}">
+        <span class="gs-leaderboard-rank">${rank}</span>
+        <span class="gs-leaderboard-name">${escapeHtml(d.nickname || "Anonymous")}</span>
+        <span class="gs-leaderboard-streak">${d.bestStreak}</span>
+        <span class="gs-leaderboard-accuracy">${accuracy}</span>
+      </li>
+    `;
+  }
+
+  async function renderList(container) {
+    if (!container) return;
+    if (!configured) {
+      container.innerHTML = '<p class="gs-leaderboard-note">Leaderboard not configured yet — see firebaseConfig.js.</p>';
+      return;
+    }
+    container.innerHTML = '<p class="gs-leaderboard-note">Loading&hellip;</p>';
+    await ready;
+    if (!uid) {
+      container.innerHTML = '<p class="gs-leaderboard-note">Could not connect to the leaderboard.</p>';
+      return;
+    }
+    try {
+      const snap = await db.collection(COLLECTION).orderBy("bestStreak", "desc").limit(TOP_N).get();
+      if (snap.empty) {
+        container.innerHTML = '<p class="gs-leaderboard-note">No scores yet — be the first!</p>';
+        return;
+      }
+      const rows = snap.docs.map((doc, i) => renderRow(doc, i + 1)).join("");
+      container.innerHTML = `<ul class="gs-leaderboard-list">${rows}</ul>`;
+    } catch (err) {
+      container.innerHTML = '<p class="gs-leaderboard-note">Could not load leaderboard.</p>';
+      console.error("Leaderboard: renderList failed", err);
+    }
+  }
+
+  // Shown/hidden alongside the local insights panel (start, pause and
+  // game-over states) — never during an active round. Re-fetches on every
+  // show, so returning to a non-playing screen picks up other players'
+  // scores since you last looked, not just your own.
+  function showPanel() {
+    const panel = document.getElementById("gsLeaderboard");
+    if (!panel) return;
+    panel.style.display = "block";
+    renderList(document.getElementById("gsLeaderboardList"));
+  }
+
+  function hidePanel() {
+    const panel = document.getElementById("gsLeaderboard");
+    if (panel) panel.style.display = "none";
+  }
+
+  return { init, submitScore, showPanel, hidePanel };
+})();
+
+if (document.getElementById("gsLeaderboard")) {
+  Leaderboard.init();
+}


### PR DESCRIPTION
Client-judged, same trust model as the existing localStorage stats — correct/incorrect is still decided in the browser, only the final streak gets shared. Firestore + Anonymous Auth, one doc per player (upserted on a new personal best), gated by security rules that require every write to actually beat the stored score server-side.

Entirely optional: leaderboard.js detects firebaseConfig.js's placeholder values and no-ops everywhere until a real project is wired up, so the rest of the game is unaffected either way. README has full setup steps (Firebase console only, no CLI/deploy needed).