### PR TITLE
Move nickname above the search bar, add a mid-round leaderboard peek

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -112,6 +112,7 @@ function initGeoStreak() {
   const highScoreEl = document.getElementById("gsHighScore");
   const countryTallyEl = document.getElementById("gsCountryTally");
   const pauseBtn = document.getElementById("gsPause");
+  const leaderboardPeekBtn = document.getElementById("gsLeaderboardPeek");
   const startEl = document.getElementById("gsStart");
   const playAreaEl = document.getElementById("gsPlayArea");
   const playControlsEl = document.getElementById("gsPlayControls");
@@ -423,6 +424,22 @@ function initGeoStreak() {
     setPausePending(!pausePending);
   }
 
+  // Outside a live round the leaderboard already shows itself automatically
+  // (see the Leaderboard.showPanel()/hidePanel() calls below) — this is
+  // only for peeking at it mid-round without pausing or otherwise touching
+  // the round in progress: the timer keeps running underneath it.
+  let leaderboardPeeked = false;
+  function toggleLeaderboardPeek() {
+    if (typeof Leaderboard === "undefined") return;
+    leaderboardPeeked = !leaderboardPeeked;
+    leaderboardPeekBtn.textContent = leaderboardPeeked ? "\u{1F3C6} Hide Leaderboard" : "\u{1F3C6} Show Leaderboard";
+    if (leaderboardPeeked) {
+      Leaderboard.showPanel();
+    } else {
+      Leaderboard.hidePanel();
+    }
+  }
+
   function enterPause() {
     paused = true;
     setPausePending(false);
@@ -516,6 +533,8 @@ function initGeoStreak() {
     pausedEl.style.display = "none";
     gameOverEl.style.display = "none";
     insightsEl.style.display = "none";
+    leaderboardPeeked = false;
+    leaderboardPeekBtn.textContent = "\u{1F3C6} Show Leaderboard";
     if (typeof Leaderboard !== "undefined") Leaderboard.hidePanel();
     playAreaEl.style.display = "";
     newCondition();
@@ -526,6 +545,7 @@ function initGeoStreak() {
     if (e.key === "Enter") submitGuess();
   });
   pauseBtn.addEventListener("click", togglePause);
+  leaderboardPeekBtn.addEventListener("click", toggleLeaderboardPeek);
   // Start/resume/play-again live inside rendered HTML, so they're delegated
   // from their containers rather than bound to elements that get replaced.
   startEl.addEventListener("click", (e) => {

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -277,9 +277,17 @@ collection, keyed by their anonymous-auth uid:
 ```
 
 A **nickname** defaults to a random `PlayerNNNN`, editable any time from
-the leaderboard panel's input — stored in
+the "Playing as" bar above the search box — visible and editable in every
+state, unlike the ranked list itself (see below) — stored in
 `localStorage["geoStreakGame_nickname"]`, and re-sent on every write so
 renaming updates future leaderboard rows without needing a migration.
+
+The ranked list itself is a different story — it's hidden while a round is
+actually live (same treatment as the local insights panel) and shows
+itself automatically on the start, pause and game-over screens. To check
+it **mid-round** without pausing, there's a "Show Leaderboard" button next
+to Pause — the timer keeps running underneath it; it's a peek, not a
+break.
 
 A run's final streak is only ever submitted **on Game Over**, and only if
 it's positive — a losing run's low number was never a personal best worth

--- a/FPL/vannilaWeatherApp/weatherGame/firebaseConfig.js
+++ b/FPL/vannilaWeatherApp/weatherGame/firebaseConfig.js
@@ -12,10 +12,10 @@
 // placeholder and no-ops everywhere — the rest of GeoStreak works exactly
 // as before, just without the online leaderboard panel.
 const firebaseConfig = {
-  apiKey: "REPLACE_ME",
-  authDomain: "REPLACE_ME.firebaseapp.com",
-  projectId: "REPLACE_ME",
-  storageBucket: "REPLACE_ME.appspot.com",
-  messagingSenderId: "REPLACE_ME",
-  appId: "REPLACE_ME",
+  apiKey: "AIzaSyAP9Y5eJKtbbzwZL8po_3GHcb3U-Na7gXc",
+  authDomain: "weathergame-bda93.firebaseapp.com",
+  projectId: "weathergame-bda93",
+  storageBucket: "weathergame-bda93.firebasestorage.app",
+  messagingSenderId: "874814445946",
+  appId: "1:874814445946:web:3fa2c10baad47b4a379ec3",
 };

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -342,10 +342,23 @@
       white-space: nowrap;
     }
 
-    .gs-nickname-row {
+    #gsPlayerBar {
       display: flex;
+      align-items: center;
       gap: 8px;
-      margin-bottom: 14px;
+      max-width: 420px;
+      margin: 0 auto 18px;
+    }
+    .gs-player-label {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.7rem;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: #6b7fa8;
+      white-space: nowrap;
+    }
+    #gsPlayerBar input {
+      flex: 1 1 auto;
     }
     .gs-leaderboard-note {
       color: #6b7fa8;
@@ -444,6 +457,22 @@
 
     <div class="gs-country-tally" id="gsCountryTally"></div>
 
+    <!-- Nickname is always visible and editable, in every state — unlike
+         the ranked list below (gsLeaderboard), which only really means
+         something once a round has actually ended. -->
+    <div id="gsPlayerBar">
+      <span class="gs-player-label">Playing as</span>
+      <input
+        type="text"
+        id="gsNickname"
+        class="form-control"
+        maxlength="20"
+        placeholder="Your name"
+        autocomplete="off"
+      />
+      <button type="button" id="gsNicknameSave" class="btn btn-secondary btn-sm">Save</button>
+    </div>
+
     <!-- Always visible, in every state, including before Start Game is ever
          pressed: while a round is live this is a guess; otherwise it's a
          plain city weather lookup, same as the main Weather.JS search. -->
@@ -474,6 +503,11 @@
         <div class="gs-timer-row">
           <div class="gs-timer" id="gsTimer">20s</div>
           <button type="button" id="gsPause" class="gs-pause-btn">&#9208; PAUSE</button>
+          <!-- Outside of a live round the leaderboard already shows itself
+               automatically (see gsInsights/gsLeaderboard toggling in
+               app.js) — this button is only needed to peek at it mid-round,
+               without pausing or otherwise interrupting the round. -->
+          <button type="button" id="gsLeaderboardPeek" class="gs-pause-btn">&#127942; Show Leaderboard</button>
         </div>
       </div>
     </div>
@@ -496,17 +530,6 @@
     <div id="gsLeaderboard" style="display: none;">
       <div class="gs-panel">
         <h3>Leaderboard</h3>
-        <div class="gs-nickname-row">
-          <input
-            type="text"
-            id="gsNickname"
-            class="form-control"
-            maxlength="20"
-            placeholder="Your name"
-            autocomplete="off"
-          />
-          <button type="button" id="gsNicknameSave" class="btn btn-secondary btn-sm">Save</button>
-        </div>
         <div id="gsLeaderboardList"></div>
       </div>
     </div>


### PR DESCRIPTION
Nickname is now always visible/editable in a "Playing as" bar, rather than living inside the leaderboard panel that's hidden during a live round. The ranked list keeps its existing auto show/hide behavior, plus a new "Show Leaderboard" button next to Pause for checking rankings mid-round without pausing.

Also wires in the real Firebase project config (values aren't secret — access control is firestore.rules' job, not this object's).

<img width="971" height="877" alt="image" src="https://github.com/user-attachments/assets/2e66e81d-be17-4ace-93d9-3794a6490adf" />
