### PR TITLE
Make GeoStreak's nickname a one-time setup, move it into the header

### DIFF
--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -276,10 +276,14 @@ collection, keyed by their anonymous-auth uid:
 { nickname: "Player4492", bestStreak: 22, totalCorrect: 125, totalAttempts: 139, updatedAt: <server timestamp> }
 ```
 
-A **nickname** defaults to a random `PlayerNNNN`, editable any time from
-the "Playing as" bar above the search box — visible and editable in every
-state, unlike the ranked list itself (see below) — stored in
-`localStorage["geoStreakGame_nickname"]`, and re-sent on every write so
+A **nickname** defaults to a random `PlayerNNNN`. Setting one is a
+one-time thing: a "Playing as" row above the search box asks for it once,
+and disappears for good the moment you hit Save — from then on the name
+just sits quietly in the header (highlighted, so it reads as *you*), with
+a small "change" link next to it that brings the row back if you ever want
+to rename. Stored in `localStorage["geoStreakGame_nickname"]` — its mere
+presence there is also how the page tells "never set a name" apart from
+"set one, first visit or the hundredth" — and re-sent on every write so
 renaming updates future leaderboard rows without needing a migration.
 
 The ranked list itself is a different story — it's hidden while a round is

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -74,6 +74,20 @@
       color: #7dd3fc;
       text-decoration: underline;
     }
+    .gs-header-nickname-wrap {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding-right: 4px;
+      border-right: 1px solid #1b2a4a;
+      margin-right: 2px;
+    }
+    .gs-header-nickname {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.85rem;
+      font-weight: bold;
+      color: #f0b429;
+    }
 
     .gs-footer {
       text-align: center;
@@ -342,23 +356,22 @@
       white-space: nowrap;
     }
 
+    /* Shown once, the first time a nickname hasn't been saved yet — its
+       .gs-input-row is the exact same width/layout as the search box
+       below it, so the two rows line up instead of one being pushed over
+       by an inline label. */
     #gsPlayerBar {
-      display: flex;
-      align-items: center;
-      gap: 8px;
       max-width: 420px;
-      margin: 0 auto 18px;
+      margin: 0 auto;
     }
     .gs-player-label {
+      display: block;
       font-family: "Courier New", Courier, monospace;
       font-size: 0.7rem;
       letter-spacing: 1px;
       text-transform: uppercase;
       color: #6b7fa8;
-      white-space: nowrap;
-    }
-    #gsPlayerBar input {
-      flex: 1 1 auto;
+      margin-bottom: 6px;
     }
     .gs-leaderboard-note {
       color: #6b7fa8;
@@ -437,6 +450,12 @@
     <div class="gs-radar"></div>
     <div class="gs-brand">TENFORBEN // STATION — GeoStreak</div>
     <div class="gs-header-links">
+      <!-- Shown once a nickname has been saved (see leaderboard.js); until
+           then #gsPlayerBar above the search box handles the first save. -->
+      <span id="gsHeaderNicknameWrap" class="gs-header-nickname-wrap" style="display: none;">
+        <span id="gsHeaderNickname" class="gs-header-nickname"></span>
+        <a href="#" id="gsChangeNickname" class="gs-back-link">change</a>
+      </span>
       <a class="gs-back-link" href="../southernHemisphere/southernHemisphere.html">Southern Hemisphere</a>
       <a class="gs-back-link" href="../../stadiumMap/stadiumMap.html">Stadiums Visited</a>
       <a class="gs-back-link" href="../index.html">&larr; Weather.JS</a>
@@ -457,20 +476,22 @@
 
     <div class="gs-country-tally" id="gsCountryTally"></div>
 
-    <!-- Nickname is always visible and editable, in every state — unlike
-         the ranked list below (gsLeaderboard), which only really means
-         something once a round has actually ended. -->
-    <div id="gsPlayerBar">
+    <!-- One-time nickname setup — shown until a name is actually saved,
+         then replaced by the header's #gsHeaderNicknameWrap for good (its
+         "change" link brings this back on demand; see leaderboard.js). -->
+    <div id="gsPlayerBar" style="display: none;">
       <span class="gs-player-label">Playing as</span>
-      <input
-        type="text"
-        id="gsNickname"
-        class="form-control"
-        maxlength="20"
-        placeholder="Your name"
-        autocomplete="off"
-      />
-      <button type="button" id="gsNicknameSave" class="btn btn-secondary btn-sm">Save</button>
+      <div class="gs-input-row">
+        <input
+          type="text"
+          id="gsNickname"
+          class="form-control"
+          maxlength="20"
+          placeholder="Your name"
+          autocomplete="off"
+        />
+        <button type="button" id="gsNicknameSave" class="btn btn-secondary">Save</button>
+      </div>
     </div>
 
     <!-- Always visible, in every state, including before Start Game is ever

--- a/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
+++ b/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
@@ -37,6 +37,14 @@ const Leaderboard = (() => {
     return localStorage.getItem(NICKNAME_KEY) || randomNickname();
   }
 
+  // Whether a name has ever actually been saved — getNickname() always
+  // returns *something* (falling back to a random one), so this is the
+  // only reliable way to tell "never set" apart from "set, and it just
+  // happens to be this one".
+  function hasNickname() {
+    return !!localStorage.getItem(NICKNAME_KEY);
+  }
+
   function setNickname(name) {
     const trimmed = name.trim().slice(0, 20);
     if (trimmed) localStorage.setItem(NICKNAME_KEY, trimmed);
@@ -70,17 +78,54 @@ const Leaderboard = (() => {
       });
   }
 
+  // The one-time setup row (#gsPlayerBar, above the search box) versus the
+  // permanent header display (#gsHeaderNicknameWrap) are mutually
+  // exclusive — exactly one is showing at any moment, toggled by whether
+  // a name has actually been saved yet, or by clicking "change".
+  function showSetupRow() {
+    const bar = document.getElementById("gsPlayerBar");
+    const headerWrap = document.getElementById("gsHeaderNicknameWrap");
+    if (bar) bar.style.display = "block";
+    if (headerWrap) headerWrap.style.display = "none";
+  }
+
+  function showHeaderDisplay() {
+    const bar = document.getElementById("gsPlayerBar");
+    const headerWrap = document.getElementById("gsHeaderNicknameWrap");
+    const headerName = document.getElementById("gsHeaderNickname");
+    if (bar) bar.style.display = "none";
+    if (headerWrap) headerWrap.style.display = "flex";
+    if (headerName) headerName.textContent = getNickname();
+  }
+
   function wireNicknameInput() {
     const input = document.getElementById("gsNickname");
     const saveBtn = document.getElementById("gsNicknameSave");
+    const changeLink = document.getElementById("gsChangeNickname");
     if (!input || !saveBtn) return;
+
     input.value = getNickname();
+    if (hasNickname()) {
+      showHeaderDisplay();
+    } else {
+      showSetupRow();
+    }
+
     saveBtn.addEventListener("click", () => {
       input.value = setNickname(input.value);
+      showHeaderDisplay();
     });
     input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") saveBtn.click();
     });
+    if (changeLink) {
+      changeLink.addEventListener("click", (e) => {
+        e.preventDefault(); // it's a styling convenience, not a real link
+        showSetupRow();
+        input.focus();
+        input.select();
+      });
+    }
   }
 
   // Called once a run ends. Only writes on a positive streak — a losing


### PR DESCRIPTION
The "Playing as" row now only shows until a name is actually saved (tracked by presence in localStorage, not just its value), then disappears for good in favour of a highlighted display in the header with a "change" link to bring the row back on demand.

Also fixes the row's alignment by reusing the same .gs-input-row layout as the search box below it, instead of an inline label pushing it out of step.