### PR TITLE
Add per-run question/answer history with a new History page

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -170,6 +170,13 @@ function initGeoStreak() {
   // city), so it can't double as this count.
   let citiesThisRun = new Set();
 
+  // Every resolved round this run, correct guesses and the one that ended
+  // it alike — sent to Firestore as a single array field on one document
+  // when the run ends (see endGame), not written round-by-round. That's
+  // the entire point: one write per finished run, however many rounds it
+  // had, instead of one write per round.
+  let roundHistory = [];
+
   // How many guesses (correct or not, but only ones that resolved to a real
   // place) have come from each country this session, keyed by ISO code.
   let countryCounts = new Map();
@@ -252,6 +259,17 @@ function initGeoStreak() {
       ui.updateTimerDisplay(timerEl, Math.max(timeLeft, 0));
       if (timeLeft <= 0) {
         stopRoundTimer();
+        roundHistory.push({
+          direction: currentCondition.direction,
+          threshold: currentCondition.threshold,
+          hemisphere: currentCondition.hemisphere || null,
+          typed: null,
+          resolvedCity: null,
+          country: null,
+          temp: null,
+          correct: false,
+          timedOut: true,
+        });
         endGame("time");
       }
     }, 1000);
@@ -385,6 +403,18 @@ function initGeoStreak() {
       correct = tempCorrect && hemisphereCorrect;
     }
 
+    roundHistory.push({
+      direction: currentCondition.direction,
+      threshold: currentCondition.threshold,
+      hemisphere: currentCondition.hemisphere || null,
+      typed,
+      resolvedCity: data.name,
+      country: countryCode,
+      temp: actual,
+      correct,
+      timedOut: false,
+    });
+
     stopRoundTimer();
     ui.renderGameCard(resultEl, data, { correct, isNewCity });
     recordAttempt(correct);
@@ -484,6 +514,7 @@ function initGeoStreak() {
     insightsEl.style.display = "block";
     if (typeof Leaderboard !== "undefined") {
       Leaderboard.submitScore(streak, stats());
+      Leaderboard.submitRunHistory(streak, reason, roundHistory);
       Leaderboard.showPanel();
     }
     // Play area stays visible (unlike Pause/Start) so the last question —
@@ -499,6 +530,7 @@ function initGeoStreak() {
     streak = 0;
     usedCities = new Set();
     citiesThisRun = new Set();
+    roundHistory = [];
     countryCounts = new Map();
     usedThresholds.above.clear();
     usedThresholds.below.clear();

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -234,13 +234,20 @@ elements:
   into empty containers, so their buttons are wired by delegating clicks
   from the container rather than binding elements that get replaced.
 - **`firebaseConfig.js`** / **`leaderboard.js`** / **`firestore.rules`** —
-  the optional online leaderboard (see [Leaderboard](#leaderboard) above).
+  the optional online leaderboard and run history (see
+  [Leaderboard](#leaderboard) and [Run History](#run-history) above).
   Firebase's compat SDK (loaded via `<script>` tags, matching this
   project's no-bundler style) plus `leaderboard.js` must both come
   *before* `../app.js` in `geoStreakGame.html` — `app.js` calls
   `showStartScreen()` synchronously as soon as it loads, and that needs
   the `Leaderboard` global (and `escapeHtml` from `../ui.js`) to already
   exist.
+- **`history.html`** / **`historyPage.js`** — the Run History page. A
+  separate page load, so it can't reuse `leaderboard.js`'s in-memory
+  Firebase state — it does its own minimal sign-in + query, self-contained
+  like `southernHemisphere/app.js` (its own small `escapeHtml`/
+  `flagEmoji`, rather than loading `../ui.js` for just those two
+  functions). Read-only: this page never writes to Firestore.
 
 ## Leaderboard
 
@@ -296,8 +303,10 @@ break.
 A run's final streak is only ever submitted **on Game Over**, and only if
 it's positive — a losing run's low number was never a personal best worth
 recording. The write is a `set(..., { merge: true })` upsert, not an
-append: there's exactly one row per player, always their personal best,
-never a full history of every run.
+append: there's exactly one row per player here, always their personal
+best. The full round-by-round record of *every* run — see
+[Run History](#run-history) below — lives in a separate collection
+entirely, written unconditionally.
 
 ### Why the rules file is the part that actually matters
 
@@ -324,6 +333,116 @@ issued. That needs the paid Blaze plan (Cloud Functions require outbound
 networking, unavailable on Spark) and is a real rework of the round loop,
 not an add-on — deliberately out of scope here in favour of shipping a
 working shared leaderboard today.
+
+## Run History
+
+A per-player, per-round log of every run ever played — not just the
+headline streak the leaderboard keeps, but every single question asked
+and every guess made along the way. Play it at
+[`history.html`](./history.html) (linked from GeoStreak's header).
+
+The motivating case: your streak dies at 5 and you want to see all 5
+correct guesses plus the one that ended it — not just the final number.
+The History page shows exactly that, one card per run, each expandable
+into a full round-by-round table (condition, what you guessed, the actual
+temperature, CORRECT / INCORRECT / TIMED OUT). Your **Personal Best** run
+— the highest `finalStreak` among your recent runs — gets its own
+highlighted section up top, pre-expanded, so a new best is always one
+click away without hunting through the list.
+
+Uses the same Firebase project as the leaderboard — no separate account
+setup. `firestore.rules` already covers both collections if you followed
+the Leaderboard section's steps. There's exactly **one** extra one-time
+step this feature needs that the leaderboard didn't:
+
+**Create a composite index.** The History page's query — every run for
+one player, `uid == X`, newest first — needs a composite index that
+Firestore doesn't build automatically. The very first time you load
+`history.html`, it'll fail with "This query needs a Firestore index" and
+log the real error to the browser console; that error's `message` contains
+a **direct link, specific to your project**, that pre-fills the index for
+you (collection `geostreakRuns`, fields `uid` Ascending + `playedAt`
+Descending) — open it, click **Create Index**, wait a minute or two for it
+to finish building (Firestore Database -> Indexes tab shows
+Building -> Enabled), then reload the page. One-time, console-only, same
+as everything else here.
+
+### Data model
+
+One document per **completed run**, in a new `geostreakRuns` collection,
+auto-generated id:
+
+```
+{
+  uid: "abc123...",
+  nickname: "Player4492",
+  finalStreak: 5,
+  reason: "wrong" | "time",
+  roundCount: 6,
+  rounds: [
+    { direction: "above", threshold: 18, hemisphere: null, typed: "Kochi",
+      resolvedCity: "Kochi", country: "IN", temp: 29.4, correct: true, timedOut: false },
+    // ...5 more, in order — the 6th being the incorrect guess or timeout that ended it
+  ],
+  playedAt: <server timestamp>,
+}
+```
+
+The key design choice: **one write per finished run, not one write per
+round.** Every round this run played is accumulated in memory
+client-side (`roundHistory` in `app.js`) and only sent to Firestore as a
+single array field, in a single `add()` call, at the moment `endGame()`
+fires. A 40-round tough-mode streak costs exactly the same one write as a
+1-round loss — Firestore bills per write call, not per array element.
+Unlike the leaderboard, this write happens on **every** run regardless of
+streak — a 0-streak instant loss is still a real attempt worth being able
+to look back at.
+
+### Privacy
+
+Unlike the public leaderboard, run history is **private** —
+`firestore.rules` only allows a player to read documents where
+`uid == request.auth.uid`. This is granular play-by-play data, not a
+headline number, so there's no reason for it to be world-readable the way
+the leaderboard is.
+
+### Why the "personal best" section doesn't need a second query
+
+Finding the single highest-streak run *could* mean a second Firestore
+query (`orderBy("finalStreak", "desc").limit(1)`) — but combining that
+with the `uid` filter needs its own composite index, on top of whatever
+the main history query already needs. Instead, the page fetches your
+`RUNS_LIMIT` (100) most recent runs once and finds the best one **among
+those**, client-side. For any realistic amount of play this is
+indistinguishable from a true all-time best — it would only miss an older,
+better run once you've played more than 100 games since it happened.
+
+### Read/write cost — what this actually adds
+
+Everything below is against Firestore's free Spark plan limits: **50,000
+reads/day, 20,000 writes/day.** Firestore bills reads **per document
+returned**, not per query — a query returning 20 docs is 20 reads, not 1.
+A write that a security rule *rejects* is free; only a write that actually
+succeeds counts.
+
+| Action | Before Run History | After Run History |
+| --- | --- | --- |
+| Finishing a run | 0–1 write (leaderboard, only if a new best) | **+1 write, always** (run history) — at most 2 total |
+| Viewing the leaderboard (start/pause/game-over/peek) | up to 20 reads | unchanged |
+| Visiting the History page | — (didn't exist) | **up to 100 reads**, only when that page is actually opened |
+
+Worked example — 10 people playing 5 runs each in a day (50 runs total),
+each checking their leaderboard 3 times per session and their history
+once:
+
+- **Writes:** 50 runs × up to 2 writes = **100 writes/day** — 0.5% of the free cap.
+- **Leaderboard reads:** 50 runs × 3 views × 20 docs = **3,000 reads/day.**
+- **History reads:** 10 visits × up to 100 docs = **1,000 reads/day.**
+- **Total: ~4,000 reads/day** — 8% of the free cap, and Run History's own
+  share of that (the only genuinely *new* cost) is about 1,000 reads and
+  50 writes — comfortably inside Spark for any personal or small-friends-group
+  scale. The leaderboard's own reads were already the larger cost before
+  this feature existed at all.
 
 ## Visual design
 

--- a/FPL/vannilaWeatherApp/weatherGame/firestore.rules
+++ b/FPL/vannilaWeatherApp/weatherGame/firestore.rules
@@ -33,6 +33,27 @@ service cloud.firestore {
 
       allow delete: if false;
     }
+
+    // Full per-run history (every round's question + guess + result), for
+    // the History page's "replay one of my runs" view. One document per
+    // completed run, auto-generated id — unlike the leaderboard above,
+    // this is written ONCE, at Game Over, and never updated again.
+    match /geostreakRuns/{runId} {
+      // Private — a player can only read their own run history, never
+      // anyone else's. This is real per-round detail, not just a headline
+      // number, so (unlike the public leaderboard) there's no reason for
+      // it to be world-readable.
+      allow read: if request.auth != null && resource.data.uid == request.auth.uid;
+
+      allow create: if request.auth != null
+        && request.auth.uid == request.resource.data.uid
+        && isValidRun(request.resource.data);
+
+      // No update path at all — a run is a historical record of what
+      // actually happened, not a value that should ever change afterward.
+      allow update: if false;
+      allow delete: if false;
+    }
   }
 
   function isValidEntry(data) {
@@ -45,5 +66,20 @@ service cloud.firestore {
       // only value that resolves to request.time, so this forces the
       // write to actually use it rather than a spoofed date.
       && data.updatedAt == request.time;
+  }
+
+  // Deliberately shallow: checks the run's own shape and bounds, not every
+  // field inside every element of `rounds` — validating each round's inner
+  // structure would be a lot of rule code to defend data that's already
+  // client-judged same as everything else here (see the top of this file).
+  function isValidRun(data) {
+    return data.keys().hasOnly(['uid', 'nickname', 'finalStreak', 'reason', 'roundCount', 'rounds', 'playedAt'])
+      && data.uid is string
+      && data.nickname is string && data.nickname.size() <= 20
+      && data.finalStreak is int && data.finalStreak >= 0 && data.finalStreak <= 500
+      && data.reason in ['wrong', 'time']
+      && data.roundCount is int && data.roundCount >= 0 && data.roundCount <= 2000
+      && data.rounds is list && data.rounds.size() == data.roundCount
+      && data.playedAt == request.time;
   }
 }

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -456,6 +456,7 @@
         <span id="gsHeaderNickname" class="gs-header-nickname"></span>
         <a href="#" id="gsChangeNickname" class="gs-back-link">change</a>
       </span>
+      <a class="gs-back-link" href="history.html">History</a>
       <a class="gs-back-link" href="../southernHemisphere/southernHemisphere.html">Southern Hemisphere</a>
       <a class="gs-back-link" href="../../stadiumMap/stadiumMap.html">Stadiums Visited</a>
       <a class="gs-back-link" href="../index.html">&larr; Weather.JS</a>

--- a/FPL/vannilaWeatherApp/weatherGame/history.html
+++ b/FPL/vannilaWeatherApp/weatherGame/history.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link
+    rel="stylesheet"
+    href="https://stackpath.bootstrapcdn.com/bootswatch/4.4.1/minty/bootstrap.min.css"
+  />
+  <title>Run History — TENFORBEN Station</title>
+  <link
+    rel="icon"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 16 16%22><text x=%228%22 y=%2213%22 font-size=%2214%22 text-anchor=%22middle%22>%F0%9F%A6%96</text></svg>"
+  />
+  <style>
+    body {
+      background: #060a14;
+      color: #cfe8ff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+    }
+
+    .gs-header {
+      background: linear-gradient(180deg, #0a1226 0%, #060a14 100%);
+      border-bottom: 1px solid #1b2a4a;
+      padding: 18px 20px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .gs-brand {
+      font-family: "Courier New", Courier, monospace;
+      letter-spacing: 1px;
+      font-size: 1rem;
+      color: #7dd3fc;
+    }
+    .gs-back-link {
+      font-family: "Courier New", Courier, monospace;
+      color: #93a4c3;
+      font-size: 0.85rem;
+      text-decoration: none;
+    }
+    .gs-back-link:hover { color: #7dd3fc; text-decoration: underline; }
+
+    main.container {
+      padding-top: 28px;
+      padding-bottom: 60px;
+      max-width: 760px;
+    }
+
+    h1 {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 1.4rem;
+      color: #e2ecff;
+      text-align: center;
+      margin-bottom: 6px;
+    }
+    .gs-status {
+      text-align: center;
+      color: #6b7fa8;
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.85rem;
+      margin-bottom: 28px;
+    }
+
+    h2.gs-section-title {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.8rem;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: #6b7fa8;
+      margin: 32px 0 14px;
+    }
+
+    /* ---- run cards ---- */
+    .gs-run-card {
+      background: #0c1630;
+      border: 1px solid #1b2a4a;
+      border-radius: 8px;
+      margin-bottom: 12px;
+      overflow: hidden;
+    }
+    .gs-run-card-best {
+      border-color: #f0b429;
+      box-shadow: 0 0 0 1px #f0b429;
+    }
+    .gs-run-toggle {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      background: transparent;
+      border: none;
+      color: inherit;
+      text-align: left;
+      padding: 14px 18px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .gs-run-toggle:hover { background: #101c3c; }
+    .gs-run-streak {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 1.4rem;
+      font-weight: bold;
+      color: #7dd3fc;
+      min-width: 2.4em;
+    }
+    .gs-run-card-best .gs-run-streak { color: #f0b429; }
+    .gs-run-meta {
+      flex: 1 1 auto;
+      font-size: 0.85rem;
+      color: #9db4de;
+    }
+    .gs-run-caret {
+      color: #6b7fa8;
+      font-size: 0.8rem;
+    }
+    .gs-run-detail {
+      border-top: 1px solid #1b2a4a;
+      padding: 4px 18px 14px;
+      overflow-x: auto;
+    }
+
+    .gs-round-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+      margin-top: 10px;
+    }
+    .gs-round-table th {
+      text-align: left;
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.68rem;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: #6b7fa8;
+      padding: 6px 10px 6px 0;
+      border-bottom: 1px solid #1b2a4a;
+    }
+    .gs-round-table td {
+      padding: 7px 10px 7px 0;
+      border-bottom: 1px solid #101a30;
+      white-space: nowrap;
+    }
+    .gs-round-table tbody tr:last-child td { border-bottom: none; }
+
+    .gs-badge {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.7rem;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+      padding: 2px 7px;
+      border-radius: 3px;
+      border: 1px solid currentColor;
+    }
+    .gs-badge-correct { color: #16a34a; }
+    .gs-badge-incorrect { color: #dc2626; }
+    .gs-badge-timeout { color: #f0b429; }
+
+    .gs-empty-note {
+      text-align: center;
+      color: #6b7fa8;
+      font-size: 0.9rem;
+      padding: 30px 0;
+    }
+    .gs-empty-note a { color: #7dd3fc; }
+  </style>
+</head>
+<body>
+  <header class="gs-header">
+    <div class="gs-brand">TENFORBEN // STATION — Run History</div>
+    <a class="gs-back-link" href="geoStreakGame.html">&larr; GeoStreak</a>
+  </header>
+
+  <main class="container">
+    <h1>Your Run History</h1>
+    <p class="gs-status" id="hStatus">Loading&hellip;</p>
+
+    <div id="hBestSection">
+      <h2 class="gs-section-title">🏆 Personal Best</h2>
+      <div id="hBest"></div>
+    </div>
+
+    <h2 class="gs-section-title">All Runs</h2>
+    <div id="hList"></div>
+  </main>
+
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/12.17.1/firebase-firestore-compat.js"></script>
+  <script src="firebaseConfig.js"></script>
+  <script src="historyPage.js"></script>
+</body>
+</html>

--- a/FPL/vannilaWeatherApp/weatherGame/historyPage.js
+++ b/FPL/vannilaWeatherApp/weatherGame/historyPage.js
@@ -1,0 +1,176 @@
+// GeoStreak run history — reads from Firestore's geostreakRuns collection,
+// scoped to the signed-in player's own runs by firestore.rules (a player
+// can only read documents where uid == their own auth uid). Entirely
+// read-only: this page never writes anything.
+//
+// Self-contained like southernHemisphere/app.js — its own small
+// escapeHtml/flagEmoji helpers rather than loading ../ui.js, since this
+// page doesn't need the rest of what that file does.
+
+// How many of the most recent runs to pull per visit. "Personal best" is
+// computed client-side from whatever this fetches, not a separate query —
+// see the README's Leaderboard section for why (avoids needing a second
+// Firestore index) and what 100 reads per visit actually costs.
+const RUNS_LIMIT = 100;
+
+const configured = typeof firebaseConfig !== "undefined"
+  && firebaseConfig.apiKey
+  && !firebaseConfig.apiKey.startsWith("REPLACE_ME");
+
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, (ch) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[ch]));
+}
+
+function flagEmoji(iso2) {
+  const cc = String(iso2 || "").toUpperCase().replace(/[^A-Z]/g, "");
+  if (cc.length !== 2) return "";
+  return String.fromCodePoint(...[...cc].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65));
+}
+
+function formatCondition(round) {
+  const dir = round.direction === "above" ? "ABOVE" : "BELOW";
+  const hemi = round.hemisphere
+    ? (round.hemisphere === "north" ? "Northern, " : "Southern, ")
+    : "";
+  return `${hemi}${dir} ${round.threshold}°C`;
+}
+
+function formatResultBadge(round) {
+  if (round.timedOut) return '<span class="gs-badge gs-badge-timeout">TIMED OUT</span>';
+  return round.correct
+    ? '<span class="gs-badge gs-badge-correct">CORRECT</span>'
+    : '<span class="gs-badge gs-badge-incorrect">INCORRECT</span>';
+}
+
+function buildRoundsTable(rounds) {
+  const rows = rounds.map((r, i) => {
+    const guess = r.timedOut
+      ? "&mdash;"
+      : `${flagEmoji(r.country)} ${escapeHtml(r.resolvedCity || "")}`;
+    const temp = r.temp != null ? `${Math.round(r.temp)}°C` : "&mdash;";
+    return `
+      <tr>
+        <td>${i + 1}</td>
+        <td>${escapeHtml(formatCondition(r))}</td>
+        <td>${guess}</td>
+        <td>${temp}</td>
+        <td>${formatResultBadge(r)}</td>
+      </tr>
+    `;
+  }).join("");
+
+  return `
+    <table class="gs-round-table">
+      <thead>
+        <tr><th>#</th><th>Condition</th><th>Guess</th><th>Temp</th><th>Result</th></tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+function formatPlayedAt(timestamp) {
+  if (!timestamp || typeof timestamp.toDate !== "function") return "just now";
+  return timestamp.toDate().toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function buildRunCard(run, { best = false } = {}) {
+  const reasonLabel = run.reason === "time" ? "Time's Up" : "Game Over";
+  const roundWord = run.roundCount === 1 ? "round" : "rounds";
+  return `
+    <div class="gs-run-card${best ? " gs-run-card-best" : ""}">
+      <button type="button" class="gs-run-toggle" aria-expanded="false">
+        <span class="gs-run-streak">${run.finalStreak}</span>
+        <span class="gs-run-meta">${escapeHtml(reasonLabel)} &middot; ${run.roundCount} ${roundWord} &middot; ${formatPlayedAt(run.playedAt)}</span>
+        <span class="gs-run-caret">&#9656;</span>
+      </button>
+      <div class="gs-run-detail" style="display: none;">
+        ${buildRoundsTable(run.rounds || [])}
+      </div>
+    </div>
+  `;
+}
+
+function wireRunToggles(container) {
+  container.querySelectorAll(".gs-run-toggle").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const detail = btn.nextElementSibling;
+      const opening = detail.style.display === "none";
+      detail.style.display = opening ? "block" : "none";
+      btn.setAttribute("aria-expanded", String(opening));
+      btn.querySelector(".gs-run-caret").innerHTML = opening ? "&#9662;" : "&#9656;";
+    });
+  });
+}
+
+async function main() {
+  const statusEl = document.getElementById("hStatus");
+  const bestSectionEl = document.getElementById("hBestSection");
+  const bestEl = document.getElementById("hBest");
+  const listEl = document.getElementById("hList");
+
+  if (!configured) {
+    statusEl.textContent = "History isn't configured yet — see firebaseConfig.js.";
+    bestSectionEl.style.display = "none";
+    return;
+  }
+
+  firebase.initializeApp(firebaseConfig);
+  const auth = firebase.auth();
+  const db = firebase.firestore();
+
+  try {
+    await auth.signInAnonymously();
+    const user = await new Promise((resolve) => {
+      const unsubscribe = auth.onAuthStateChanged((u) => {
+        if (!u) return;
+        unsubscribe();
+        resolve(u);
+      });
+    });
+
+    const snap = await db.collection("geostreakRuns")
+      .where("uid", "==", user.uid)
+      .orderBy("playedAt", "desc")
+      .limit(RUNS_LIMIT)
+      .get();
+
+    if (snap.empty) {
+      statusEl.innerHTML = 'No runs recorded on this browser yet — play a round of <a href="geoStreakGame.html">GeoStreak</a> first.';
+      bestSectionEl.style.display = "none";
+      return;
+    }
+
+    const runs = snap.docs.map((doc) => doc.data());
+    const best = runs.reduce((a, b) => (b.finalStreak > a.finalStreak ? b : a), runs[0]);
+
+    statusEl.textContent = runs.length === RUNS_LIMIT
+      ? `Showing your ${RUNS_LIMIT} most recent runs.`
+      : `${runs.length} run${runs.length === 1 ? "" : "s"} on this account.`;
+
+    bestEl.innerHTML = buildRunCard(best, { best: true });
+    listEl.innerHTML = runs.map((r) => buildRunCard(r)).join("");
+    wireRunToggles(bestEl);
+    wireRunToggles(listEl);
+  } catch (err) {
+    console.error("History: load failed", err);
+    bestSectionEl.style.display = "none";
+    if (err && err.code === "failed-precondition") {
+      // Firestore's own error for this includes a direct link to
+      // auto-create the missing composite index — that link only shows up
+      // in the real browser console (err.message), not here, since it's
+      // specific to this Firebase project.
+      statusEl.textContent = "This query needs a Firestore index — open the browser console for a one-click link to create it.";
+    } else {
+      statusEl.textContent = "Could not load your history.";
+    }
+  }
+}
+
+main();

--- a/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
+++ b/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
@@ -16,6 +16,7 @@
 const Leaderboard = (() => {
   const NICKNAME_KEY = "geoStreakGame_nickname";
   const COLLECTION = "geostreakLeaderboard";
+  const RUNS_COLLECTION = "geostreakRuns";
   const TOP_N = 20;
 
   const configured = typeof firebaseConfig !== "undefined"
@@ -153,6 +154,36 @@ const Leaderboard = (() => {
     }
   }
 
+  // Called once a run ends, regardless of streak — unlike submitScore(),
+  // even a zero/immediate-loss run is worth recording, since the whole
+  // point (see history.html) is being able to look back at *every*
+  // attempt, not just the good ones. One document per run, written once,
+  // with every round embedded as a plain array field — not one write per
+  // round, and not a subcollection either, both of which would multiply
+  // the write/read cost for no real benefit at this scale. See the
+  // README's Leaderboard section for the actual read/write numbers this
+  // adds up to.
+  async function submitRunHistory(streak, reason, rounds) {
+    if (!configured) return;
+    await ready;
+    if (!uid) return;
+    try {
+      await db.collection(RUNS_COLLECTION).add({
+        uid,
+        nickname: getNickname(),
+        finalStreak: streak,
+        reason: reason === "time" ? "time" : "wrong",
+        roundCount: rounds.length,
+        rounds,
+        playedAt: firebase.firestore.FieldValue.serverTimestamp(),
+      });
+    } catch (err) {
+      // Same "fail silently" reasoning as submitScore() — a background
+      // write that didn't make it shouldn't interrupt Game Over.
+      console.error("Leaderboard: submitRunHistory failed", err);
+    }
+  }
+
   function renderRow(doc, rank) {
     const d = doc.data();
     const accuracy = d.totalAttempts
@@ -211,7 +242,7 @@ const Leaderboard = (() => {
     if (panel) panel.style.display = "none";
   }
 
-  return { init, submitScore, showPanel, hidePanel };
+  return { init, submitScore, submitRunHistory, showPanel, hidePanel };
 })();
 
 if (document.getElementById("gsLeaderboard")) {


### PR DESCRIPTION
app.js accumulates every round of a run (condition, guess, resolved city, temp, correct/timed-out) in memory and writes the whole run as one Firestore document on Game Over — one write per finished run, never per round, regardless of streak length.

New geostreakRuns collection, private per-player (read: owner-only) and write-once (no update/delete path). history.html links from GeoStreak's header and shows a highlighted Personal Best run plus every run chronologically, each expandable into the full round-by- round table.

README documents the data model, the one-time composite-index setup step, and a read/write cost breakdown against Firestore's free tier.
<img width="1388" height="1040" alt="image" src="https://github.com/user-attachments/assets/da1fd869-ab56-443d-8067-81af91f17111" />
