### PR TITLE
Add PDF export to GeoStreak's History page

### DIFF
--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -350,6 +350,16 @@ temperature, CORRECT / INCORRECT / TIMED OUT). Your **Personal Best** run
 highlighted section up top, pre-expanded, so a new best is always one
 click away without hunting through the list.
 
+**Export PDF** is the browser's own print dialog with "Save as PDF" picked
+as the destination — no PDF library, no server round-trip. Clicking it
+force-expands every run card (so nothing you never happened to click open
+is silently missing from the export) and hands off to `window.print()`;
+a `@media print` stylesheet in `history.html` swaps the dark console
+theme for a plain light one just for the printed/exported version, since
+printing the dark theme as-is would either waste a page of ink or — if
+the browser's "background graphics" print option is off — render as
+invisible white-on-white.
+
 Uses the same Firebase project as the leaderboard — no separate account
 setup. `firestore.rules` already covers both collections if you followed
 the Leaderboard section's steps. There's exactly **one** extra one-time

--- a/FPL/vannilaWeatherApp/weatherGame/history.html
+++ b/FPL/vannilaWeatherApp/weatherGame/history.html
@@ -164,6 +164,52 @@
       padding: 30px 0;
     }
     .gs-empty-note a { color: #7dd3fc; }
+
+    .gs-toolbar {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 28px;
+    }
+    .gs-export-btn {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.8rem;
+      letter-spacing: 0.5px;
+      color: #7dd3fc;
+      background: #0c1630;
+      border: 1px solid #1b2a4a;
+      border-radius: 6px;
+      padding: 7px 14px;
+      cursor: pointer;
+    }
+    .gs-export-btn:hover { border-color: #1f6feb; color: #a9e2ff; }
+
+    /* Printing (or "Save as PDF", the same browser feature) gets its own
+       light, ink-friendly theme rather than the dark console look — a
+       dark background either wastes a page of ink or, worse, prints as
+       invisible white-on-white if the browser's "background graphics"
+       option is off. Everything below only applies inside a print
+       context; the on-screen page is untouched. */
+    @media print {
+      body { background: #fff; color: #14213d; }
+      .gs-header, .gs-toolbar, .gs-run-caret { display: none; }
+      h1, .gs-status, h2.gs-section-title { color: #14213d; }
+      .gs-run-card, .gs-run-card-best {
+        background: #fff;
+        border: 1px solid #ccc;
+        box-shadow: none;
+        break-inside: avoid;
+      }
+      .gs-run-toggle { cursor: default; }
+      .gs-run-streak { color: #14213d; }
+      .gs-run-card-best .gs-run-streak { color: #b45309; }
+      .gs-run-meta { color: #555; }
+      .gs-run-detail { display: block !important; border-top-color: #ddd; }
+      .gs-round-table th { color: #666; border-bottom-color: #ccc; }
+      .gs-round-table td { color: #14213d; border-bottom-color: #eee; }
+      .gs-badge-correct { color: #15803d; }
+      .gs-badge-incorrect { color: #b91c1c; }
+      .gs-badge-timeout { color: #b45309; }
+    }
   </style>
 </head>
 <body>
@@ -175,6 +221,10 @@
   <main class="container">
     <h1>Your Run History</h1>
     <p class="gs-status" id="hStatus">Loading&hellip;</p>
+
+    <div class="gs-toolbar">
+      <button type="button" id="hExportPdf" class="gs-export-btn">&#128196; Export PDF</button>
+    </div>
 
     <div id="hBestSection">
       <h2 class="gs-section-title">🏆 Personal Best</h2>

--- a/FPL/vannilaWeatherApp/weatherGame/historyPage.js
+++ b/FPL/vannilaWeatherApp/weatherGame/historyPage.js
@@ -109,6 +109,22 @@ function wireRunToggles(container) {
   });
 }
 
+// "Export PDF" is just the browser's native print dialog with "Save as
+// PDF" as the destination — no library, no server round-trip. The only
+// real work is making sure nothing's missing from it: a run card the
+// player never happened to expand shouldn't just vanish from their
+// export, so every card is forced open first. The @media print rules in
+// history.html handle swapping the dark theme for a printable one.
+function exportToPdf() {
+  document.querySelectorAll(".gs-run-detail").forEach((detail) => {
+    detail.style.display = "block";
+  });
+  document.querySelectorAll(".gs-run-toggle").forEach((btn) => {
+    btn.setAttribute("aria-expanded", "true");
+  });
+  window.print();
+}
+
 async function main() {
   const statusEl = document.getElementById("hStatus");
   const bestSectionEl = document.getElementById("hBestSection");
@@ -172,5 +188,8 @@ async function main() {
     }
   }
 }
+
+const exportBtn = document.getElementById("hExportPdf");
+if (exportBtn) exportBtn.addEventListener("click", exportToPdf);
 
 main();


### PR DESCRIPTION
Uses the browser's native print dialog ("Save as PDF") rather than a PDF library — Export PDF force-expands every run card first so nothing unopened is silently missing, then hands off to window.print(). A @media print stylesheet swaps the dark console theme for a light, ink-friendly one just for the exported version.


<img width="1687" height="922" alt="image" src="https://github.com/user-attachments/assets/fec86e85-1a44-4c9a-8c87-0a16621f121b" />
