### PR TITLE
Paginate GeoStreak's leaderboard past 10 entries

### DIFF
--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -300,6 +300,18 @@ it **mid-round** without pausing, there's a "Show Leaderboard" button next
 to Pause — the timer keeps running underneath it; it's a peek, not a
 break.
 
+**Pagination** kicks in past 10 entries — 10 rows per page, with Prev/Next
+controls that only render at all once there's actually a second page to go
+to. Firestore has no cheap "give me page N" or row-count query, so each
+page fetch asks for 11 rows instead of 10 purely to learn whether a Next
+page exists, and "Prev" is answered by remembering the cursor for each
+page already seen this panel-open rather than re-deriving it — paging
+backward through cursors you've already walked, not a fresh reverse query.
+Reopening the panel (leaving and coming back to a non-playing screen)
+always starts back on page 1, since the ranking can easily have changed
+since you last looked and trying to preserve a page position across that
+isn't worth the complexity.
+
 A run's final streak is only ever submitted **on Game Over**, and only if
 it's positive — a losing run's low number was never a personal best worth
 recording. The write is a `set(..., { merge: true })` upsert, not an
@@ -431,28 +443,29 @@ better run once you've played more than 100 games since it happened.
 
 Everything below is against Firestore's free Spark plan limits: **50,000
 reads/day, 20,000 writes/day.** Firestore bills reads **per document
-returned**, not per query — a query returning 20 docs is 20 reads, not 1.
+returned**, not per query — a query returning 10 docs is 10 reads, not 1.
 A write that a security rule *rejects* is free; only a write that actually
 succeeds counts.
 
 | Action | Before Run History | After Run History |
 | --- | --- | --- |
 | Finishing a run | 0–1 write (leaderboard, only if a new best) | **+1 write, always** (run history) — at most 2 total |
-| Viewing the leaderboard (start/pause/game-over/peek) | up to 20 reads | unchanged |
+| Viewing the leaderboard, one page (start/pause/game-over/peek) | up to 20 reads | **up to 11 reads** (pagination's 10-per-page + 1 to check for a next page) |
 | Visiting the History page | — (didn't exist) | **up to 100 reads**, only when that page is actually opened |
 
 Worked example — 10 people playing 5 runs each in a day (50 runs total),
-each checking their leaderboard 3 times per session and their history
-once:
+each checking their leaderboard 3 times per session (one page each) and
+their history once:
 
 - **Writes:** 50 runs × up to 2 writes = **100 writes/day** — 0.5% of the free cap.
-- **Leaderboard reads:** 50 runs × 3 views × 20 docs = **3,000 reads/day.**
+- **Leaderboard reads:** 50 runs × 3 views × 11 docs = **1,650 reads/day.**
 - **History reads:** 10 visits × up to 100 docs = **1,000 reads/day.**
-- **Total: ~4,000 reads/day** — 8% of the free cap, and Run History's own
+- **Total: ~2,650 reads/day** — 5% of the free cap, and Run History's own
   share of that (the only genuinely *new* cost) is about 1,000 reads and
   50 writes — comfortably inside Spark for any personal or small-friends-group
-  scale. The leaderboard's own reads were already the larger cost before
-  this feature existed at all.
+  scale. Pagination actually *lowered* the leaderboard's own per-view cost
+  along the way (20 reads flat -> 11 for a first page), since most visits
+  never go past page 1.
 
 ## Visual design
 

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -401,7 +401,7 @@
     .gs-leaderboard-rank {
       font-family: "Courier New", Courier, monospace;
       color: #6b7fa8;
-      width: 1.6em;
+      width: 2.2em;
       text-align: right;
       flex-shrink: 0;
     }
@@ -423,6 +423,32 @@
       font-size: 0.75rem;
       width: 3em;
       text-align: right;
+    }
+
+    .gs-pagination {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .gs-page-btn {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.75rem;
+      letter-spacing: 0.5px;
+      color: #93a4c3;
+      background: transparent;
+      border: 1px solid #1b2a4a;
+      border-radius: 4px;
+      padding: 4px 10px;
+      cursor: pointer;
+    }
+    .gs-page-btn:hover:not(:disabled) { color: #7dd3fc; border-color: #1f6feb; }
+    .gs-page-btn:disabled { color: #40506e; cursor: not-allowed; }
+    .gs-page-label {
+      font-family: "Courier New", Courier, monospace;
+      font-size: 0.75rem;
+      color: #6b7fa8;
     }
 
     .gs-howto {
@@ -553,6 +579,7 @@
       <div class="gs-panel">
         <h3>Leaderboard</h3>
         <div id="gsLeaderboardList"></div>
+        <div id="gsLeaderboardPagination" class="gs-pagination"></div>
       </div>
     </div>
 

--- a/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
+++ b/FPL/vannilaWeatherApp/weatherGame/leaderboard.js
@@ -17,7 +17,7 @@ const Leaderboard = (() => {
   const NICKNAME_KEY = "geoStreakGame_nickname";
   const COLLECTION = "geostreakLeaderboard";
   const RUNS_COLLECTION = "geostreakRuns";
-  const TOP_N = 20;
+  const PAGE_SIZE = 10;
 
   const configured = typeof firebaseConfig !== "undefined"
     && firebaseConfig.apiKey
@@ -29,6 +29,16 @@ const Leaderboard = (() => {
   // below awaits this first, so a call made right on page load doesn't
   // race the auth handshake.
   let ready = Promise.resolve();
+
+  // pageCursors[i] is the document to startAfter() when fetching page i —
+  // pageCursors[0] is always null (the first page needs no cursor).
+  // Firestore has no cheap "give me page N directly" query, so paging
+  // backward means walking back through cursors already seen this panel
+  // session rather than re-deriving them, which is why this (and
+  // currentPage) reset to a blank slate every time the panel opens fresh
+  // rather than trying to persist across views.
+  let pageCursors = [null];
+  let currentPage = 0;
 
   function randomNickname() {
     return `Player${Math.floor(1000 + Math.random() * 9000)}`;
@@ -200,41 +210,92 @@ const Leaderboard = (() => {
     `;
   }
 
-  async function renderList(container) {
+  // Fetches PAGE_SIZE rows for `pageIndex`, plus one extra (PAGE_SIZE + 1
+  // total) purely to answer "is there a page after this one?" cheaply —
+  // Firestore has no free row-count, so the alternative would be a whole
+  // separate query just to know whether to show a Next button.
+  async function fetchLeaderboardPage(pageIndex) {
+    let query = db.collection(COLLECTION).orderBy("bestStreak", "desc");
+    if (pageCursors[pageIndex]) query = query.startAfter(pageCursors[pageIndex]);
+    const snap = await query.limit(PAGE_SIZE + 1).get();
+    const hasNext = snap.docs.length > PAGE_SIZE;
+    const pageDocs = snap.docs.slice(0, PAGE_SIZE);
+    // Remember where the *next* page starts, but only the first time we
+    // see it — re-deriving it on every visit to this page would be wasted
+    // work since the cursor (a specific document) doesn't change.
+    if (hasNext && !pageCursors[pageIndex + 1]) {
+      pageCursors[pageIndex + 1] = pageDocs[pageDocs.length - 1];
+    }
+    return { pageDocs, hasNext };
+  }
+
+  // Pagination controls only appear once they'd actually do something —
+  // a leaderboard with 10 or fewer entries has nothing to page through.
+  function renderPagination(container, pageIndex, hasNext) {
     if (!container) return;
+    if (pageIndex === 0 && !hasNext) {
+      container.innerHTML = "";
+      return;
+    }
+    container.innerHTML = `
+      <button type="button" id="gsLbPrev" class="gs-page-btn" ${pageIndex === 0 ? "disabled" : ""}>&larr; Prev</button>
+      <span class="gs-page-label">Page ${pageIndex + 1}</span>
+      <button type="button" id="gsLbNext" class="gs-page-btn" ${hasNext ? "" : "disabled"}>Next &rarr;</button>
+    `;
+    const listEl = document.getElementById("gsLeaderboardList");
+    const prevBtn = document.getElementById("gsLbPrev");
+    const nextBtn = document.getElementById("gsLbNext");
+    if (prevBtn) prevBtn.addEventListener("click", () => renderPage(listEl, pageIndex - 1));
+    if (nextBtn) nextBtn.addEventListener("click", () => renderPage(listEl, pageIndex + 1));
+  }
+
+  async function renderPage(container, pageIndex) {
+    if (!container) return;
+    const paginationEl = document.getElementById("gsLeaderboardPagination");
     if (!configured) {
       container.innerHTML = '<p class="gs-leaderboard-note">Leaderboard not configured yet — see firebaseConfig.js.</p>';
       return;
     }
     container.innerHTML = '<p class="gs-leaderboard-note">Loading&hellip;</p>';
+    if (paginationEl) paginationEl.innerHTML = "";
     await ready;
     if (!uid) {
       container.innerHTML = '<p class="gs-leaderboard-note">Could not connect to the leaderboard.</p>';
       return;
     }
     try {
-      const snap = await db.collection(COLLECTION).orderBy("bestStreak", "desc").limit(TOP_N).get();
-      if (snap.empty) {
-        container.innerHTML = '<p class="gs-leaderboard-note">No scores yet — be the first!</p>';
+      const { pageDocs, hasNext } = await fetchLeaderboardPage(pageIndex);
+      if (pageDocs.length === 0) {
+        container.innerHTML = pageIndex === 0
+          ? '<p class="gs-leaderboard-note">No scores yet — be the first!</p>'
+          : '<p class="gs-leaderboard-note">No more scores.</p>';
         return;
       }
-      const rows = snap.docs.map((doc, i) => renderRow(doc, i + 1)).join("");
+      currentPage = pageIndex;
+      const startRank = pageIndex * PAGE_SIZE + 1;
+      const rows = pageDocs.map((doc, i) => renderRow(doc, startRank + i)).join("");
       container.innerHTML = `<ul class="gs-leaderboard-list">${rows}</ul>`;
+      renderPagination(paginationEl, pageIndex, hasNext);
     } catch (err) {
       container.innerHTML = '<p class="gs-leaderboard-note">Could not load leaderboard.</p>';
-      console.error("Leaderboard: renderList failed", err);
+      console.error("Leaderboard: renderPage failed", err);
     }
   }
 
   // Shown/hidden alongside the local insights panel (start, pause and
   // game-over states) — never during an active round. Re-fetches on every
   // show, so returning to a non-playing screen picks up other players'
-  // scores since you last looked, not just your own.
+  // scores since you last looked, not just your own. Always reopens on
+  // page 1 — cursors from a previous visit this session are stale enough
+  // (the ranking could easily have changed) that starting over is simpler
+  // and more correct than trying to preserve a page position.
   function showPanel() {
     const panel = document.getElementById("gsLeaderboard");
     if (!panel) return;
     panel.style.display = "block";
-    renderList(document.getElementById("gsLeaderboardList"));
+    pageCursors = [null];
+    currentPage = 0;
+    renderPage(document.getElementById("gsLeaderboardList"), 0);
   }
 
   function hidePanel() {


### PR DESCRIPTION
10 rows per page with cursor-based Prev/Next, controls only rendered once there's actually a second page. Each page fetches 11 docs (10 + 1) purely to answer "is there a next page" without a separate count query; "Prev" walks back through cursors already seen this panel-open rather than re-deriving them. No new Firestore index needed — a single-field orderBy is auto-indexed, unlike the History page's query.

As a side effect this lowers the leaderboard's typical per-view read cost (20 flat -> 11 for a first page), updated in the README's cost table alongside the new pagination behavior.

<img width="1761" height="939" alt="image" src="https://github.com/user-attachments/assets/7f0cee87-684e-4605-8929-a791e4d2b724" />
