### PR TITLE
Fix used-city dedup wrongly blocking same-named cities in other count…

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -369,19 +369,26 @@ function initGeoStreak() {
 
     // A differently-typed query can still resolve to a place already used
     // this session (e.g. "Auckland" then "Auckland,NZ") — catch that too,
-    // now that we know its canonical name.
-    if (usedCities.has(data.name.toLowerCase())) {
-      hintEl.textContent = `You've already used ${data.name} this session. Try a different city.`;
+    // now that we know its canonical name. Keyed on name+country together,
+    // not the bare resolved name: OpenWeather's `name` alone doesn't
+    // disambiguate same-named cities in different countries (Queenstown
+    // exists in NZ, AU and ZA; Colón in AR and CO — genuinely different
+    // places that just happen to share a name), so keying on name alone
+    // would wrongly block every one of them after using just one.
+    const countryCode = data.sys.country;
+    const cityKey = `${data.name}|${countryCode}`;
+    const resolvedKey = cityKey.toLowerCase();
+
+    if (usedCities.has(resolvedKey)) {
+      hintEl.textContent = `You've already used ${data.name}, ${countryCode} this session. Try a different city.`;
       return;
     }
     usedCities.add(typed.toLowerCase());
-    usedCities.add(data.name.toLowerCase());
+    usedCities.add(resolvedKey);
 
-    const countryCode = data.sys.country;
     countryCounts.set(countryCode, (countryCounts.get(countryCode) || 0) + 1);
     ui.updateCountryTally(countryTallyEl, countryCounts);
 
-    const cityKey = `${data.name}|${countryCode}`;
     const isNewCity = recordCityAttempt(cityKey);
     citiesThisRun.add(cityKey);
 

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -58,12 +58,20 @@ Once tough mode kicks in for a run, it stays on for the rest of that run —
 dropping back below 10 correct never happens, since a wrong guess ends the
 run outright.
 
-Each place name can only be used **once per session** (one continuous
-streak run) — guessing "Auckland" and then "Auckland" again later in the
-same run is rejected with a hint, no penalty, timer keeps running. Checked
+Each place can only be used **once per session** (one continuous streak
+run) — guessing "Auckland" and then "Auckland" again later in the same run
+is rejected with a hint, no penalty, timer keeps running. Checked
 case-insensitively and against the API's resolved name too, so "Auckland"
-and "auckland,NZ" count as the same entry. The used-city list resets on
-Play Again.
+and "auckland,NZ" count as the same entry.
+
+The resolved-name check is keyed on **name + country together**, not the
+bare name — OpenWeather's resolved city name alone doesn't disambiguate
+same-named cities in different countries (there's a Queenstown in NZ, AU
+*and* ZA; a Colón in both AR and CO), so using one used to wrongly block
+every other one for the rest of the run. Guessing "Queenstown,NZ" then
+later "Queenstown,ZA" in the same run is two different real places and is
+allowed; guessing "Queenstown,NZ" twice is still caught as the same one.
+The used-city list resets on Play Again.
 
 ## Round timer
 


### PR DESCRIPTION
…ries

usedCities keyed the resolved-name check on data.name alone, so Queenstown (NZ/AU/ZA) or Colón (AR/CO) collided with each other after using just one — same name, genuinely different places. Now keyed on name+country together, matching the cityKey format already used for the country tally and lifetime city stats.

<img width="1692" height="951" alt="image" src="https://github.com/user-attachments/assets/1ba88d43-e2d1-4286-a923-26e20ffc1134" />
