### PR TITLE
Show why a tough round failed: temp, hemisphere, or both

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -410,9 +410,10 @@ function initGeoStreak() {
     // (lat 0) counts as northern, matching the >= 0 convention ui.js
     // already uses for daylight calculations.
     let correct = tempCorrect;
+    let hemisphereCorrect = null;
     if (currentCondition.hemisphere) {
       const northern = data.coord.lat >= 0;
-      const hemisphereCorrect = currentCondition.hemisphere === "north" ? northern : !northern;
+      hemisphereCorrect = currentCondition.hemisphere === "north" ? northern : !northern;
       correct = tempCorrect && hemisphereCorrect;
     }
 
@@ -425,6 +426,12 @@ function initGeoStreak() {
       country: countryCode,
       temp: actual,
       correct,
+      // Only meaningful on tough rounds (hemisphere set) — lets History
+      // show *which* half of a combined condition actually failed, rather
+      // than just "INCORRECT" with no way to tell temperature from
+      // hemisphere without recomputing it from the city's coordinates.
+      tempCorrect,
+      hemisphereCorrect,
       timedOut: false,
     });
 

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -536,6 +536,16 @@ Notable bugs, once actually fixed — what broke, what it looked like to a
 player, and the real cause, newest first. Not every commit, just the ones
 worth a future reader knowing *why* the code is shaped the way it is.
 
+- **2026-08-17 — History's INCORRECT badge didn't say why a tough round
+  failed.** A tough round (hemisphere + temperature) needs both halves
+  right, but a failed one just showed "INCORRECT" with no way to tell
+  whether the temperature guess, the hemisphere guess, or both were wrong
+  — the player had to recompute it by hand from the city and reading.
+  Fixed by recording `tempCorrect`/`hemisphereCorrect` alongside `correct`
+  in each round (`app.js`), and having `historyPage.js` turn that into
+  "INCORRECT (temp)", "(hemisphere)", or "(temp & hemisphere)". Runs
+  recorded before this fix don't have the two new fields, so they still
+  show a plain "INCORRECT" rather than guessing.
 - **2026-08-16 — Correctness judged against the raw temperature, not the
   rounded one the card displays.** The result card always showed
   `Math.round(data.main.temp)` (e.g. "16°C"), but the correct/incorrect

--- a/FPL/vannilaWeatherApp/weatherGame/historyPage.js
+++ b/FPL/vannilaWeatherApp/weatherGame/historyPage.js
@@ -43,9 +43,19 @@ function formatCondition(round) {
 
 function formatResultBadge(round) {
   if (round.timedOut) return '<span class="gs-badge gs-badge-timeout">TIMED OUT</span>';
-  return round.correct
-    ? '<span class="gs-badge gs-badge-correct">CORRECT</span>'
-    : '<span class="gs-badge gs-badge-incorrect">INCORRECT</span>';
+  if (round.correct) return '<span class="gs-badge gs-badge-correct">CORRECT</span>';
+
+  // Tough rounds fail one of two independent conditions (temperature,
+  // hemisphere) — runs recorded before this breakdown existed have
+  // tempCorrect/hemisphereCorrect as undefined, so this only annotates
+  // rounds where we actually know which one broke.
+  let reason = "";
+  if (round.hemisphere && round.tempCorrect != null && round.hemisphereCorrect != null) {
+    if (!round.tempCorrect && !round.hemisphereCorrect) reason = " (temp &amp; hemisphere)";
+    else if (!round.tempCorrect) reason = " (temp)";
+    else if (!round.hemisphereCorrect) reason = " (hemisphere)";
+  }
+  return `<span class="gs-badge gs-badge-incorrect">INCORRECT${reason}</span>`;
 }
 
 function buildRoundsTable(rounds) {


### PR DESCRIPTION
History's INCORRECT badge gave no way to tell which half of a combined hemisphere+temperature condition actually failed. Rounds now record tempCorrect/hemisphereCorrect alongside the combined result, and the badge spells out which one broke.

 
<img width="1540" height="981" alt="image" src="https://github.com/user-attachments/assets/68fa08eb-a5f4-4f0f-98d4-7347163d79e2" />
