### PR TITLE
Show which cities are behind each country in the tally on hover

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -177,9 +177,12 @@ function initGeoStreak() {
   // had, instead of one write per round.
   let roundHistory = [];
 
-  // How many guesses (correct or not, but only ones that resolved to a real
+  // Which cities (correct or not, but only ones that resolved to a real
   // place) have come from each country this session, keyed by ISO code.
-  let countryCounts = new Map();
+  // The count shown in the tally is just this array's length — usedCities
+  // already stops the same city+country combo appearing twice, so every
+  // entry here is a genuinely distinct place.
+  let countryCities = new Map();
 
   // Direction strictly alternates round to round (not a fresh coin flip
   // each time) — starting side is randomised once per session so it isn't
@@ -386,8 +389,9 @@ function initGeoStreak() {
     usedCities.add(typed.toLowerCase());
     usedCities.add(resolvedKey);
 
-    countryCounts.set(countryCode, (countryCounts.get(countryCode) || 0) + 1);
-    ui.updateCountryTally(countryTallyEl, countryCounts);
+    if (!countryCities.has(countryCode)) countryCities.set(countryCode, []);
+    countryCities.get(countryCode).push(data.name);
+    ui.updateCountryTally(countryTallyEl, countryCities);
 
     const isNewCity = recordCityAttempt(cityKey);
     citiesThisRun.add(cityKey);
@@ -552,7 +556,7 @@ function initGeoStreak() {
     usedCities = new Set();
     citiesThisRun = new Set();
     roundHistory = [];
-    countryCounts = new Map();
+    countryCities = new Map();
     usedThresholds.above.clear();
     usedThresholds.below.clear();
     usedToughThresholds.above.clear();
@@ -564,7 +568,7 @@ function initGeoStreak() {
     setRoundLive(false);
     hintEl.textContent = "";
     ui.updateStreakDisplay(streakEl, streak);
-    ui.updateCountryTally(countryTallyEl, countryCounts);
+    ui.updateCountryTally(countryTallyEl, countryCities);
     clearResult();
   }
 

--- a/FPL/vannilaWeatherApp/ui.js
+++ b/FPL/vannilaWeatherApp/ui.js
@@ -420,16 +420,24 @@ class UI {
   }
 
   // Renders the session's per-country breakdown, e.g. "🇧🇷 BR ×2 | 🇦🇷 AR ×1",
-  // from a Map of ISO country code -> count. Reuses flagEmoji() rather than
-  // the CDN flagImg() — this is a compact inline tally, not a card header.
-  updateCountryTally(el, countryCounts) {
+  // from a Map of ISO country code -> array of city names used from it.
+  // Each chip is hoverable/focusable and expands a small popover listing
+  // those cities, so "BR ×2" doesn't require remembering which two. Reuses
+  // flagEmoji() rather than the CDN flagImg() — this is a compact inline
+  // tally, not a card header.
+  updateCountryTally(el, countryCities) {
     if (!el) return;
-    if (countryCounts.size === 0) {
+    if (countryCities.size === 0) {
       el.innerHTML = "";
       return;
     }
-    el.innerHTML = [...countryCounts.entries()]
-      .map(([code, count]) => `${flagEmoji(code)} ${escapeHtml(code)} &times;${count}`)
+    el.innerHTML = [...countryCities.entries()]
+      .map(([code, cities]) => `
+        <span class="gs-tally-chip" tabindex="0">
+          ${flagEmoji(code)} ${escapeHtml(code)} &times;${cities.length}
+          <span class="gs-tally-popover">${cities.map(escapeHtml).join("<br>")}</span>
+        </span>
+      `)
       .join(" &nbsp;|&nbsp; ");
   }
 

--- a/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
+++ b/FPL/vannilaWeatherApp/weatherGame/geoStreakGame.html
@@ -154,6 +154,34 @@
       margin-bottom: 22px;
     }
 
+    .gs-tally-chip {
+      position: relative;
+      cursor: default;
+      border-bottom: 1px dotted #4a5f8f;
+      outline: none;
+    }
+    .gs-tally-popover {
+      display: none;
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: #0f1830;
+      border: 1px solid #2c3d63;
+      border-radius: 6px;
+      padding: 8px 12px;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: #cfe0ff;
+      white-space: nowrap;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+      z-index: 10;
+    }
+    .gs-tally-chip:hover .gs-tally-popover,
+    .gs-tally-chip:focus .gs-tally-popover {
+      display: block;
+    }
+
     .gs-condition {
       text-align: center;
       font-size: 1.15rem;


### PR DESCRIPTION
The "IN x5" style tally only ever showed a count. Now each flag chip tracks the actual cities used from that country and reveals them in a hover/focus popover, so the count doesn't require remembering what backs it.