### PR TITLE
Add per-run PDF export, temp-closeness colors, and distance tracking

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -428,6 +428,10 @@ function initGeoStreak() {
       typed,
       resolvedCity: data.name,
       country: countryCode,
+      // Coordinates, so History can compute the distance between
+      // consecutive cities per round without a second lookup.
+      lat: data.coord.lat,
+      lon: data.coord.lon,
       temp: actual,
       correct,
       // Only meaningful on tough rounds (hemisphere set) — lets History
@@ -525,6 +529,23 @@ function initGeoStreak() {
     resultEl.classList.remove("geo-result-fade-out");
   }
 
+  // Sum of the great-circle distance between each consecutive pair of
+  // guessed cities this run, in the order they were guessed — a rough
+  // "how far did this run travel" figure. Timed-out rounds have no
+  // coordinates (nothing was guessed) and are skipped, same as any round
+  // from before coordinates were recorded (older stored runs) — the chain
+  // just picks back up from the next round that has them.
+  function totalRunDistanceKm() {
+    let total = 0;
+    let last = null;
+    for (const round of roundHistory) {
+      if (round.lat == null || round.lon == null) continue;
+      if (last) total += haversineKm(last.lat, last.lon, round.lat, round.lon);
+      last = round;
+    }
+    return Math.round(total);
+  }
+
   function endGame(reason) {
     roundId += 1; // invalidate any guess still in flight for the round that just ended
     stopRoundTimer();
@@ -533,7 +554,7 @@ function initGeoStreak() {
     hintEl.textContent = "";
     gamesPlayed += 1;
     localStorage.setItem(GAMES_PLAYED_KEY, String(gamesPlayed));
-    ui.renderGameOver(gameOverEl, streak, { reason, uniqueCities: citiesThisRun.size });
+    ui.renderGameOver(gameOverEl, streak, { reason, uniqueCities: citiesThisRun.size, totalDistanceKm: totalRunDistanceKm() });
     ui.renderInsights(insightsEl, stats());
     insightsEl.style.display = "block";
     if (typeof Leaderboard !== "undefined") {

--- a/FPL/vannilaWeatherApp/ui.js
+++ b/FPL/vannilaWeatherApp/ui.js
@@ -571,7 +571,9 @@ class UI {
   // `reason: "time"` distinguishes a timeout loss from a wrong-guess loss.
   // `uniqueCities` is this run's count (not lifetime) — how many different
   // real places were pulled a reading from before the run ended.
-  renderGameOver(container, finalStreak, { reason, uniqueCities = 0 } = {}) {
+  // `totalDistanceKm` is the great-circle distance strung across every
+  // guess in order, city to city — app.js's totalRunDistanceKm().
+  renderGameOver(container, finalStreak, { reason, uniqueCities = 0, totalDistanceKm = 0 } = {}) {
     if (!container) return;
     const heading = reason === "time" ? "Time's Up!" : "Game Over";
     container.innerHTML = `
@@ -579,6 +581,7 @@ class UI {
         <h3>${heading}</h3>
         <p class="gs-panel-sub">Final streak: <b>${finalStreak}</b></p>
         <p class="gs-panel-sub">Unique cities this run: <b>${uniqueCities}</b></p>
+        <p class="gs-panel-sub">Distance traveled this run: <b>${totalDistanceKm.toLocaleString()} km</b></p>
         <button type="button" id="gsPlayAgain" class="btn btn-warning">Play Again</button>
       </div>
     `;

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -112,6 +112,13 @@ different real places you pulled a reading from before the run ended
 (correct guesses and the one that ended it, not duplicates or not-founds).
 This is a per-run count, not the lifetime one below.
 
+It also shows **distance traveled this run** — the great-circle distance
+strung across every guessed city in order, city to city
+(`totalRunDistanceKm()` in `app.js`, reusing `haversineKm()` from
+`ui.js`). Same figure the History page builds up per round in its
+Distance column (see below) — this is just that column's final row,
+computed straight from the run in progress rather than a saved one.
+
 ## The search box is always there
 
 The city input and its button sit at the top of the page in every state —
@@ -415,15 +422,35 @@ temperature, CORRECT / INCORRECT / TIMED OUT). Your **Personal Best** run
 highlighted section up top, pre-expanded, so a new best is always one
 click away without hunting through the list.
 
-**Export PDF** is the browser's own print dialog with "Save as PDF" picked
-as the destination — no PDF library, no server round-trip. Clicking it
-force-expands every run card (so nothing you never happened to click open
-is silently missing from the export) and hands off to `window.print()`;
-a `@media print` stylesheet in `history.html` swaps the dark console
-theme for a plain light one just for the printed/exported version, since
-printing the dark theme as-is would either waste a page of ink or — if
-the browser's "background graphics" print option is off — render as
-invisible white-on-white.
+Each round's **Temp** column is color-highlighted by how close the
+reading landed to the threshold it was judged against — independent of
+CORRECT/INCORRECT, since a near-miss and a comfortable pass are both
+worth calling out. Exactly at the threshold is gold; within 2 degrees
+either side is green; anything wider gets no color
+(`tempClosenessClass()` in `historyPage.js`).
+
+The **Distance** column is a running total, not per-row: 0 on the first
+guessed city, then the great-circle distance added on as each next city
+gets guessed, so the last row is the whole run's traveled distance
+(`buildDistanceColumn()` in `historyPage.js`, its own copy of
+`ui.js`'s `haversineKm()` per this page's self-contained convention). A
+round with no coordinates — timed out, or an older run recorded before
+coordinates were saved (`lat`/`lon` on each round in `app.js`) — shows
+"—" and breaks the running chain right there rather than guessing;
+the total picks back up from the next round that has them.
+
+**Export** (the 📄 button on each run card) is the browser's own print
+dialog with "Save as PDF" picked as the destination — no PDF library, no
+server round-trip — but scoped to just that one run, not the whole page:
+`wireExportButtons()` force-expands that single card (so a never-clicked
+card still exports in full), marks it via `body.gs-printing-one` +
+`.gs-print-target`, and hands off to `window.print()`. A `@media print`
+stylesheet in `history.html` hides every other run card for the duration,
+and swaps the dark console theme for a plain light one, since printing
+the dark theme as-is would either waste a page of ink or — if the
+browser's "background graphics" print option is off — render as
+invisible white-on-white. An `afterprint` listener restores everything
+(other cards, this card's open/closed state) once the dialog closes.
 
 Uses the same Firebase project as the leaderboard — no separate account
 setup. `firestore.rules` already covers both collections if you followed

--- a/FPL/vannilaWeatherApp/weatherGame/history.html
+++ b/FPL/vannilaWeatherApp/weatherGame/history.html
@@ -84,8 +84,13 @@
       border-color: #f0b429;
       box-shadow: 0 0 0 1px #f0b429;
     }
+    .gs-run-header-row {
+      display: flex;
+      align-items: stretch;
+    }
     .gs-run-toggle {
-      width: 100%;
+      flex: 1 1 auto;
+      min-width: 0;
       display: flex;
       align-items: center;
       gap: 14px;
@@ -98,6 +103,17 @@
       font-family: inherit;
     }
     .gs-run-toggle:hover { background: #101c3c; }
+    .gs-run-export-btn {
+      flex: 0 0 auto;
+      background: transparent;
+      border: none;
+      border-left: 1px solid #1b2a4a;
+      color: #6b7fa8;
+      font-size: 0.95rem;
+      padding: 0 16px;
+      cursor: pointer;
+    }
+    .gs-run-export-btn:hover { color: #7dd3fc; background: #101c3c; }
     .gs-run-streak {
       font-family: "Courier New", Courier, monospace;
       font-size: 1.4rem;
@@ -157,6 +173,13 @@
     .gs-badge-incorrect { color: #dc2626; }
     .gs-badge-timeout { color: #f0b429; }
 
+    /* How close a reading landed to the threshold it was judged against,
+       independent of correct/incorrect — exactly at the threshold (gold)
+       or within 2 degrees of it (green). See tempClosenessClass() in
+       historyPage.js. */
+    .gs-temp-gold { color: #f0b429; font-weight: bold; }
+    .gs-temp-green { color: #16a34a; font-weight: bold; }
+
     .gs-empty-note {
       text-align: center;
       color: #6b7fa8;
@@ -164,24 +187,6 @@
       padding: 30px 0;
     }
     .gs-empty-note a { color: #7dd3fc; }
-
-    .gs-toolbar {
-      display: flex;
-      justify-content: center;
-      margin-bottom: 28px;
-    }
-    .gs-export-btn {
-      font-family: "Courier New", Courier, monospace;
-      font-size: 0.8rem;
-      letter-spacing: 0.5px;
-      color: #7dd3fc;
-      background: #0c1630;
-      border: 1px solid #1b2a4a;
-      border-radius: 6px;
-      padding: 7px 14px;
-      cursor: pointer;
-    }
-    .gs-export-btn:hover { border-color: #1f6feb; color: #a9e2ff; }
 
     /* Printing (or "Save as PDF", the same browser feature) gets its own
        light, ink-friendly theme rather than the dark console look — a
@@ -191,7 +196,7 @@
        context; the on-screen page is untouched. */
     @media print {
       body { background: #fff; color: #14213d; }
-      .gs-header, .gs-toolbar, .gs-run-caret { display: none; }
+      .gs-header, .gs-run-caret, .gs-run-export-btn { display: none; }
       h1, .gs-status, h2.gs-section-title { color: #14213d; }
       .gs-run-card, .gs-run-card-best {
         background: #fff;
@@ -209,6 +214,15 @@
       .gs-badge-correct { color: #15803d; }
       .gs-badge-incorrect { color: #b91c1c; }
       .gs-badge-timeout { color: #b45309; }
+      .gs-temp-gold { color: #b45309; }
+      .gs-temp-green { color: #15803d; }
+
+      /* Set on <body> by a per-run "export this run" click (see
+         wireExportButtons in historyPage.js) — hides every OTHER run card
+         so the PDF contains just the one the player asked for, not the
+         whole page. */
+      body.gs-printing-one .gs-run-card:not(.gs-print-target) { display: none; }
+      body.gs-printing-one h2.gs-section-title { display: none; }
     }
   </style>
 </head>
@@ -221,10 +235,6 @@
   <main class="container">
     <h1>Your Run History</h1>
     <p class="gs-status" id="hStatus">Loading&hellip;</p>
-
-    <div class="gs-toolbar">
-      <button type="button" id="hExportPdf" class="gs-export-btn">&#128196; Export PDF</button>
-    </div>
 
     <div id="hBestSection">
       <h2 class="gs-section-title">🏆 Personal Best</h2>

--- a/FPL/vannilaWeatherApp/weatherGame/historyPage.js
+++ b/FPL/vannilaWeatherApp/weatherGame/historyPage.js
@@ -58,12 +58,65 @@ function formatResultBadge(round) {
   return `<span class="gs-badge gs-badge-incorrect">INCORRECT${reason}</span>`;
 }
 
+// How close the reading landed to the threshold it was judged against —
+// independent of correct/incorrect, since a near-miss and a comfortable
+// pass are both worth calling out differently from an ordinary result.
+// Exactly AT the threshold is the closest a reading can get (gold); within
+// 2 degrees either side is still a close margin (green); anything wider
+// gets no special color.
+function tempClosenessClass(r) {
+  if (r.timedOut || r.temp == null || r.threshold == null) return "";
+  const diff = Math.abs(r.temp - r.threshold);
+  if (diff === 0) return "gs-temp-gold";
+  if (diff <= 2) return "gs-temp-green";
+  return "";
+}
+
+// Great-circle distance (km) between two lat/lon points, via the haversine
+// formula. Duplicated from ui.js rather than loaded — see the top-of-file
+// note on why this page stays self-contained.
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371; // mean Earth radius, km
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// Running total of the distance strung across the cities guessed so far
+// this run, city to city in order — 0 on the first guessed city, and by
+// the last row the whole run's traveled distance. A round with no
+// coordinates (timed out, or an older run recorded before coordinates
+// were saved) breaks the chain right there rather than guessing at it —
+// its own cell shows nothing, and the running total picks back up from
+// the next round that does have them.
+function buildDistanceColumn(rounds) {
+  let total = 0;
+  let last = null;
+  return rounds.map((r) => {
+    if (r.lat == null || r.lon == null) {
+      last = null;
+      return null;
+    }
+    if (last) total += haversineKm(last.lat, last.lon, r.lat, r.lon);
+    last = r;
+    return Math.round(total);
+  });
+}
+
 function buildRoundsTable(rounds) {
+  const distances = buildDistanceColumn(rounds);
   const rows = rounds.map((r, i) => {
     const guess = r.timedOut
       ? "&mdash;"
       : `${flagEmoji(r.country)} ${escapeHtml(r.resolvedCity || "")}`;
-    const temp = r.temp != null ? `${Math.round(r.temp)}°C` : "&mdash;";
+    const temp = r.temp != null
+      ? `<span class="${tempClosenessClass(r)}">${Math.round(r.temp)}°C</span>`
+      : "&mdash;";
+    const distance = distances[i] != null ? `${distances[i].toLocaleString()} km` : "&mdash;";
     return `
       <tr>
         <td>${i + 1}</td>
@@ -71,6 +124,7 @@ function buildRoundsTable(rounds) {
         <td>${guess}</td>
         <td>${temp}</td>
         <td>${formatResultBadge(r)}</td>
+        <td>${distance}</td>
       </tr>
     `;
   }).join("");
@@ -78,7 +132,7 @@ function buildRoundsTable(rounds) {
   return `
     <table class="gs-round-table">
       <thead>
-        <tr><th>#</th><th>Condition</th><th>Guess</th><th>Temp</th><th>Result</th></tr>
+        <tr><th>#</th><th>Condition</th><th>Guess</th><th>Temp</th><th>Result</th><th>Distance</th></tr>
       </thead>
       <tbody>${rows}</tbody>
     </table>
@@ -95,11 +149,14 @@ function buildRunCard(run, { best = false } = {}) {
   const roundWord = run.roundCount === 1 ? "round" : "rounds";
   return `
     <div class="gs-run-card${best ? " gs-run-card-best" : ""}">
-      <button type="button" class="gs-run-toggle" aria-expanded="false">
-        <span class="gs-run-streak">${run.finalStreak}</span>
-        <span class="gs-run-meta">${escapeHtml(reasonLabel)} &middot; ${run.roundCount} ${roundWord} &middot; ${formatPlayedAt(run.playedAt)}</span>
-        <span class="gs-run-caret">&#9656;</span>
-      </button>
+      <div class="gs-run-header-row">
+        <button type="button" class="gs-run-toggle" aria-expanded="false">
+          <span class="gs-run-streak">${run.finalStreak}</span>
+          <span class="gs-run-meta">${escapeHtml(reasonLabel)} &middot; ${run.roundCount} ${roundWord} &middot; ${formatPlayedAt(run.playedAt)}</span>
+          <span class="gs-run-caret">&#9656;</span>
+        </button>
+        <button type="button" class="gs-run-export-btn" title="Export this run as PDF">&#128196;</button>
+      </div>
       <div class="gs-run-detail" style="display: none;">
         ${buildRoundsTable(run.rounds || [])}
       </div>
@@ -110,7 +167,10 @@ function buildRunCard(run, { best = false } = {}) {
 function wireRunToggles(container) {
   container.querySelectorAll(".gs-run-toggle").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const detail = btn.nextElementSibling;
+      // Not nextElementSibling — the toggle now sits inside .gs-run-header-row
+      // alongside the export button, so .gs-run-detail is its card's child,
+      // not its own sibling.
+      const detail = btn.closest(".gs-run-card").querySelector(".gs-run-detail");
       const opening = detail.style.display === "none";
       detail.style.display = opening ? "block" : "none";
       btn.setAttribute("aria-expanded", String(opening));
@@ -119,20 +179,44 @@ function wireRunToggles(container) {
   });
 }
 
-// "Export PDF" is just the browser's native print dialog with "Save as
-// PDF" as the destination — no library, no server round-trip. The only
-// real work is making sure nothing's missing from it: a run card the
-// player never happened to expand shouldn't just vanish from their
-// export, so every card is forced open first. The @media print rules in
-// history.html handle swapping the dark theme for a printable one.
-function exportToPdf() {
-  document.querySelectorAll(".gs-run-detail").forEach((detail) => {
-    detail.style.display = "block";
+// Exports just ONE run — not the whole page — as a PDF via the browser's
+// native print dialog ("Save as PDF" as the destination, no library, no
+// server round-trip). `body.gs-printing-one` + `.gs-print-target` (set
+// here, read by the @media print rules in history.html) hide every other
+// run card for the duration of the print. The clicked run's own detail is
+// forced open first so a never-expanded card still exports in full, and
+// its open/closed state is put back afterward exactly as the player left it.
+function wireExportButtons(container) {
+  container.querySelectorAll(".gs-run-export-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const card = btn.closest(".gs-run-card");
+      const detail = card.querySelector(".gs-run-detail");
+      const toggle = card.querySelector(".gs-run-toggle");
+      const wasOpen = detail.style.display !== "none";
+
+      if (!wasOpen) {
+        detail.style.display = "block";
+        toggle.setAttribute("aria-expanded", "true");
+        toggle.querySelector(".gs-run-caret").innerHTML = "&#9662;";
+      }
+      card.classList.add("gs-print-target");
+      document.body.classList.add("gs-printing-one");
+
+      const restore = () => {
+        document.body.classList.remove("gs-printing-one");
+        card.classList.remove("gs-print-target");
+        if (!wasOpen) {
+          detail.style.display = "none";
+          toggle.setAttribute("aria-expanded", "false");
+          toggle.querySelector(".gs-run-caret").innerHTML = "&#9656;";
+        }
+        window.removeEventListener("afterprint", restore);
+      };
+      window.addEventListener("afterprint", restore);
+
+      window.print();
+    });
   });
-  document.querySelectorAll(".gs-run-toggle").forEach((btn) => {
-    btn.setAttribute("aria-expanded", "true");
-  });
-  window.print();
 }
 
 async function main() {
@@ -184,6 +268,8 @@ async function main() {
     listEl.innerHTML = runs.map((r) => buildRunCard(r)).join("");
     wireRunToggles(bestEl);
     wireRunToggles(listEl);
+    wireExportButtons(bestEl);
+    wireExportButtons(listEl);
   } catch (err) {
     console.error("History: load failed", err);
     bestSectionEl.style.display = "none";
@@ -198,8 +284,5 @@ async function main() {
     }
   }
 }
-
-const exportBtn = document.getElementById("hExportPdf");
-if (exportBtn) exportBtn.addEventListener("click", exportToPdf);
 
 main();


### PR DESCRIPTION
History page: replace the whole-page "Export PDF" button with a per-run export button (prints just that one run's card, restores state after); color-highlight the Temp column by how close each reading landed to its threshold (gold = exact, green = within 2 degrees); add a running Distance column that totals the great-circle distance strung across guessed cities in order.

GeoStreak's Game Over screen now shows the same total distance for the run that just ended.

Also fixes a toggle-expand regression introduced while wiring the per-run export button (btn.nextElementSibling no longer pointed at .gs-run-detail once the toggle was wrapped alongside the export button).
<img width="1526" height="918" alt="image" src="https://github.com/user-attachments/assets/dff06d8a-3365-4def-84ac-1389e22f2ed0" />
