### PR TITLE
Squeeze tough rounds' temperature range by season and hemisphere

### DIFF
--- a/FPL/vannilaWeatherApp/app.js
+++ b/FPL/vannilaWeatherApp/app.js
@@ -88,6 +88,17 @@ function initGeoStreak() {
   const TOUGH_STREAK = 10;
   const TOUGH_MIN_THRESHOLD = 10;
   const TOUGH_MAX_THRESHOLD = 30;
+  // Tough rounds pin a temperature condition to ONE hemisphere, unlike the
+  // plain rounds above which can be satisfied by any city on Earth — so
+  // the wrong-season extreme of TOUGH_MIN/MAX_THRESHOLD can ask for
+  // something that's realistically almost nowhere on that half of the
+  // planet right now (e.g. "Southern, ABOVE 30°C" in southern winter,
+  // when only a handful of deep-tropical southern cities even reach that).
+  // This squeezes the hard-to-satisfy end of the range for whichever
+  // hemisphere+direction combo is currently fighting its own season —
+  // using fixed 3-month meteorological blocks (not solstice-exact dates,
+  // which this doesn't need) rather than a smooth day-by-day taper.
+  const SEASONAL_SQUEEZE = 3;
   const ROUND_SECONDS = 20;
   const RESULT_VISIBLE_MS = 4000; // how long a correct-guess card stays up before fading
   const RESULT_FADE_MS = 500; // must match the CSS transition duration on .geo-result-fade-out
@@ -203,6 +214,29 @@ function initGeoStreak() {
   // tough rounds don't always open on "north".
   let nextHemisphere = Math.random() < 0.5 ? "north" : "south";
 
+  // Narrows [TOUGH_MIN_THRESHOLD, TOUGH_MAX_THRESHOLD] toward whichever end
+  // is realistic for this hemisphere right now. A hemisphere in its own
+  // winter gets its ABOVE ceiling pulled in (few hot readings to be found);
+  // one in its own summer gets its BELOW floor pulled up (few cold ones) —
+  // the other three combinations (a hemisphere's own summer+ABOVE, its own
+  // winter+BELOW, or either hemisphere during a shoulder-season month) are
+  // already the easy/plentiful case and keep the full range.
+  function toughThresholdRange(hemisphere, direction) {
+    const month = new Date().getMonth(); // 0 = Jan … 11 = Dec, visitor's local calendar
+    const northernSummer = month >= 5 && month <= 7; // Jun–Aug: N summer, S winter
+    const northernWinter = month === 11 || month <= 1; // Dec–Feb: N winter, S summer
+    const inOwnWinter = (hemisphere === "north" && northernWinter)
+      || (hemisphere === "south" && northernSummer);
+    const inOwnSummer = (hemisphere === "north" && northernSummer)
+      || (hemisphere === "south" && northernWinter);
+
+    let min = TOUGH_MIN_THRESHOLD;
+    let max = TOUGH_MAX_THRESHOLD;
+    if (direction === "above" && inOwnWinter) max -= SEASONAL_SQUEEZE;
+    if (direction === "below" && inOwnSummer) min += SEASONAL_SQUEEZE;
+    return { min, max };
+  }
+
   function pickThreshold(pool, direction, min, max) {
     const used = pool[direction];
     let remaining = [];
@@ -308,7 +342,8 @@ function initGeoStreak() {
     if (streak >= TOUGH_STREAK) {
       const hemisphere = nextHemisphere;
       nextHemisphere = hemisphere === "north" ? "south" : "north"; // strictly alternate next round
-      const threshold = pickThreshold(usedToughThresholds, direction, TOUGH_MIN_THRESHOLD, TOUGH_MAX_THRESHOLD);
+      const { min, max } = toughThresholdRange(hemisphere, direction);
+      const threshold = pickThreshold(usedToughThresholds, direction, min, max);
       currentCondition = { direction, threshold, hemisphere };
     } else {
       const threshold = pickThreshold(usedThresholds, direction, MIN_THRESHOLD, MAX_THRESHOLD);

--- a/FPL/vannilaWeatherApp/documentation/seasonal-squeeze.md
+++ b/FPL/vannilaWeatherApp/documentation/seasonal-squeeze.md
@@ -1,0 +1,70 @@
+# The Seasonal Squeeze
+
+Why a tough round's temperature range bends with the calendar, hemisphere by hemisphere.
+
+A tough round (GeoStreak, question 11+) pins a temperature condition to
+one hemisphere, unlike a plain round which any city on Earth can satisfy.
+That's a problem for a fixed **10–30°C** range: in southern winter,
+almost nothing south of the equator reads `ABOVE 30°C` outside a handful
+of deep-tropical cities. `toughThresholdRange()` in
+[`../app.js`](../app.js) now narrows whichever end of the range is
+fighting its own hemisphere's season, and widens back out the moment it
+isn't.
+
+## Decision path
+
+```mermaid
+flowchart TD
+  A["New tough round<br/>hemisphere + direction picked"] --> B{"This hemisphere's<br/>current season?"}
+  B -->|"own winter"| C{"direction?"}
+  B -->|"own summer"| D{"direction?"}
+  B -->|"shoulder<br/>Mar&ndash;May &middot; Sep&ndash;Nov"| E["full range<br/>10&ndash;30&deg;C"]
+
+  C -->|"ABOVE"| F["squeeze ceiling<br/>30&deg;C &rarr; 27&deg;C"]
+  C -->|"BELOW"| G["full range<br/>10&ndash;30&deg;C"]
+
+  D -->|"BELOW"| H["squeeze floor<br/>10&deg;C &rarr; 13&deg;C"]
+  D -->|"ABOVE"| I["full range<br/>10&ndash;30&deg;C"]
+
+  classDef entry fill:#0a1226,stroke:#2c3d63,color:#f2f7ff,stroke-width:1px;
+  classDef season fill:#0a1226,stroke:#2c3d63,color:#7dd3fc,stroke-width:1.5px;
+  classDef cool fill:#12233f,stroke:#7dd3fc,color:#eaf7ff,stroke-width:2px;
+  classDef warm fill:#2a2110,stroke:#f0b429,color:#fff2d6,stroke-width:2px;
+  classDef full fill:#0c1630,stroke:#1b2a4a,color:#9db4de,stroke-width:1px;
+
+  class A entry
+  class B,C,D season
+  class F cool
+  class H warm
+  class E,G,I full
+```
+
+A round's hemisphere and direction are picked first; only then does the
+current month narrow the range — and only on the combination that's
+actually hard to satisfy this season.
+
+- 🟦 **ceiling squeezed** — this hemisphere's own winter, direction ABOVE
+- 🟨 **floor squeezed** — this hemisphere's own summer, direction BELOW
+- ⬛ **full 10–30°C range** — every other combination, including both
+  hemispheres during the Mar–May / Sep–Nov shoulder months
+
+## Worked months
+
+| Month | Northern · ABOVE | Northern · BELOW | Southern · ABOVE | Southern · BELOW |
+|---|---|---|---|---|
+| **April** (shoulder season) | 10–30°C | 10–30°C | 10–30°C | 10–30°C |
+| **August** (N summer, S winter) | 10–30°C | **13–30°C** | **10–27°C** | 10–30°C |
+| **December** (N winter, S summer) | **10–27°C** | 10–30°C | 10–30°C | **13–30°C** |
+
+## Constants in play
+
+| | |
+|---|---|
+| Base range | 10–30°C |
+| Squeeze amount | 3°C |
+| Northern summer window | Jun–Aug |
+| Northern winter window | Dec–Feb |
+
+Implemented in `toughThresholdRange()`, `FPL/vannilaWeatherApp/app.js` —
+fixed 3-month meteorological blocks off the visitor's local calendar
+month, not solstice-exact dates.

--- a/FPL/vannilaWeatherApp/weatherGame/README.md
+++ b/FPL/vannilaWeatherApp/weatherGame/README.md
@@ -62,6 +62,21 @@ Once tough mode kicks in for a run, it stays on for the rest of that run —
 dropping back below 10 correct never happens, since a wrong guess ends the
 run outright.
 
+That 10-30°C range also gets **squeezed by season**, per hemisphere+
+direction: a hemisphere in its own winter has its ABOVE ceiling pulled in
+3°C (to 27°C) — realistically there aren't many cities on that half of
+the planet running hot in their own winter — and a hemisphere in its own
+summer gets its BELOW floor pulled up 3°C (to 13°C) for the mirror
+reason. The other two combinations (a hemisphere's own summer+ABOVE, its
+own winter+BELOW) are already the plentiful case and keep the full range,
+as do both hemispheres during the Mar-May / Sep-Nov shoulder months.
+Fixed 3-month meteorological blocks off the visitor's local calendar
+month (`toughThresholdRange()` in `app.js`), not solstice-exact dates —
+this only needs to broadly track which half of the year it is, not
+precise transition days. Without this, e.g. "Southern, ABOVE 30°C" in
+southern winter (roughly Jun-Aug) was asking for something only a handful
+of deep-tropical southern cities could ever satisfy.
+
 Each place can only be used **once per session** (one continuous streak
 run) — guessing "Auckland" and then "Auckland" again later in the same run
 is rejected with a hint, no penalty, timer keeps running. Checked


### PR DESCRIPTION
A hemisphere in its own winter loses 3° off its ABOVE ceiling (27 instead of 30), one in its own summer gains 3° on its BELOW floor (13 instead of 10) — fixed 3-month meteorological blocks off the visitor's local calendar. Fixes tough rounds asking for near-impossible readings like "Southern, ABOVE 30°C" during southern winter, without hardcoding a fix that would go stale once the seasons flip.