### PR TITLE
Link FPL Scrapper from the site's FPL home nav and weather app

### DIFF
--- a/FPL/HoMe.html
+++ b/FPL/HoMe.html
@@ -108,6 +108,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         
             </div>
   </div>
+  <a href="scrapper/index.html" id="scrapperNav">FPL Scrapper</a>
   <a href="ProjectsDashboard.html" id="mofL">Min</a>
   <a href="../TrainingTurf/css/ImageMaps/RedentlyWatched.html" id="Lingk"> Movies</a>
   <a href="GW/GW38/FPL6/budgetTrips.html" id="kundi">Trips</a>

--- a/FPL/vannilaWeatherApp/index.html
+++ b/FPL/vannilaWeatherApp/index.html
@@ -55,6 +55,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 			<a class="btn btn-danger" id="imp" href="home.html" >Home <span id="bild"> </a>
             <a class="btn btn-primary" id="thirdBtn" href="roman.html" >Roman <span id="bilder"> </a>
             <a class="btn btn-warning" id="gameBtn" href="weatherGame/geoStreakGame.html">GeoStreak</a>
+            <a class="btn btn-success" id="fplScrapperBtn" href="../scrapper/index.html">FPL Scrapper</a>
         </div>
         <!-- <a href="/players/jonathan-leko/422153/" class="flag_16 left_16 england_16_left">J. Leko</a></span> -->
 		


### PR DESCRIPTION
FPL/scrapper/index.html had no way in from the live site — add a nav link on FPL/HoMe.html and a button on vannilaWeatherApp/index.html so it's actually reachable by clicking through instead of only via a direct URL.