### PR TITLE
Disable Scrape FPL leagues' schedule — every run has been failing

### DIFF
--- a/.github/workflows/scrape-fpl-leagues.yml
+++ b/.github/workflows/scrape-fpl-leagues.yml
@@ -1,13 +1,19 @@
 name: Scrape FPL leagues
 
 on:
-  schedule:
-    # Minute 0, 10, 20... every hour, UTC — keeps Firestore fresh enough
-    # for the punkte.html Refresh button to be worth clicking during a
-    # live gameweek. Runs unconditionally year-round (same tradeoff the
-    # Southern Hemisphere weather workflow makes) rather than trying to
-    # gate it to actual kickoff windows.
-    - cron: "*/10 * * * *"
+  # Schedule disabled 2026-08-23 — every run since this was added has
+  # failed (see the Actions tab), so it was just burning minutes every
+  # 10 minutes for nothing. Re-add a `schedule:` block once whatever's
+  # failing (check a run's "Run scrape.js" step log) is actually fixed;
+  # until then this only runs when triggered manually below.
+  #
+  # schedule:
+  #   # Minute 0, 10, 20... every hour, UTC — keeps Firestore fresh enough
+  #   # for the punkte.html Refresh button to be worth clicking during a
+  #   # live gameweek. Runs unconditionally year-round (same tradeoff the
+  #   # Southern Hemisphere weather workflow makes) rather than trying to
+  #   # gate it to actual kickoff windows.
+  #   - cron: "*/10 * * * *"
   workflow_dispatch: {} # lets you fire it manually from the Actions tab too
 
 # Unlike scrape-southern-hemisphere-weather.yml, this workflow never


### PR DESCRIPTION
380 runs, all failures, every 10 minutes, since this was added — just burning Actions minutes. Comments out the schedule trigger rather than deleting it, and leaves workflow_dispatch so it can still be run manually to debug. Re-enable once the actual failure (check a run's step log in the Actions tab) is fixed.